### PR TITLE
Default the errors collection to an empty hash instead of nil.

### DIFF
--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -54,17 +54,23 @@ module JsonApiResource
       if match = method.to_s.match(/^(.*)=$/)
         self.client.send(match[1], args.first)
       elsif self.client.respond_to?(method.to_sym)
-        self.client.send(method)
+        is_method = self.client.methods.include?(method.to_sym)
+        argument_count = is_method ? self.client.method(method.to_sym).arity : 0
+        if argument_count > 0 || argument_count == -1
+          self.client.send(method, args.first)
+        else
+          self.client.send(method)
+        end
       else
         super
       end
     end
 
     def errors
-      error_list = JsonApiResource::ApiErrors(self.client.errors).each do | k,messages|
+      JsonApiResource::ApiErrors(self.client.errors).each do | k,messages|
         self.errors.add(k.to_sym, Array(messages).join(', '))
       end
-      error_list || {}
+      self.errors
     end
 
     def self.method_missing(method, *args, &block)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -51,7 +51,7 @@ module JsonApiResource
     protected
 
     def method_missing(method, *args, &block)
-      if match = method.to_s.match(/^(.*)=$/)
+      if match = method.to_s.match(/^(.*=)$/)
         self.client.send(match[1], args.first)
       elsif self.client.respond_to?(method.to_sym)
         is_method = self.client.methods.include?(method.to_sym)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -61,9 +61,10 @@ module JsonApiResource
     end
 
     def errors
-      JsonApiResource::ApiErrors(self.client.errors).each do | k,messages|
+      error_list = JsonApiResource::ApiErrors(self.client.errors).each do | k,messages|
         self.errors.add(k.to_sym, Array(messages).join(', '))
       end
+      error_list || {}
     end
 
     def self.method_missing(method, *args, &block)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -73,6 +73,10 @@ module JsonApiResource
       self.errors
     end
 
+    def catch_errors
+
+    end
+
     def self.method_missing(method, *args, &block)
       if match = method.to_s.match(/^(.*)=$/)
         self.client_klass.send(match[1], args.first)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -55,11 +55,10 @@ module JsonApiResource
         self.client.send(match[1], args.first)
       elsif self.client.respond_to?(method.to_sym)
         is_method = self.client.methods.include?(method.to_sym)
-        argument_count = is_method ? self.client.method(method.to_sym).arity : 0
-        if argument_count > 0 || argument_count == -1
-          self.client.send(method, args.first)
-        else
+        if (is_method ? self.client.method(method.to_sym).arity : 0) == 0
           self.client.send(method)
+        else
+          self.client.send(method, args.first)
         end
       else
         super


### PR DESCRIPTION
This supports checks like resource.errors[:property].present? without first checking for resource.errors.nil?
