### PR TITLE
Pass through query metadata from json_api_client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ config/secrets.yml
 /vendor/assets/bower_components
 *.bowerrc
 bower.json
+
+.idea/

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -43,18 +43,22 @@ module JsonApiResource
       def get_single_result(result_set)
         single_result = result_set.first
 
-        single_result.methods.select{|method_name| is_query_result_setter_method(method_name)}.each do |setter_method_name|
-          getter_method_name = setter_method_name.to_s.gsub("=", "")
-          if (result_set.methods.include?(getter_method_name.to_sym))
-            single_result.send(setter_method_name, result_set.send(getter_method_name))
+        query_methods(single_result).each do |setter|
+          getter = setter.to_s.gsub("=", "")
+          if (result_set.methods.respond_to?(getter.to_sym))
+            single_result.send(setter, result_set.send(getter))
           end
         end
 
         return single_result
       end
 
-      def is_query_result_setter_method(method_name)
-        QUERY_RESULT_METADATA_SETTERS.include?(method_name.to_sym)
+      def query_methods(single_obj)
+        methods = []
+        QUERY_RESULT_METADATA_SETTERS.each do |setter|
+          methods << setter if single_obj.respond_to?(setter)
+        end
+        methods
       end
 
     end

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -2,14 +2,19 @@ module JsonApiResource
   module Queryable
     extend ActiveSupport::Concern
 
+    attr_accessor :query_result_meta
+    attr_accessor :query_result_linked_data
+    attr_accessor :query_result_errors
+
     module ClassMethods
+
       def find(id)
         return nil unless id.present?
         set = (self.client_klass.find(id)).map! do |result|
           self.new(:client => result)
         end
-        set.size == 1 ? set.first : set
-      rescue JsonApiClient::Errors::ServerError=> e
+        set.size == 1 ? get_single_result(set) : set
+      rescue JsonApiClient::Errors::ServerError => e
         []
       end
 
@@ -27,6 +32,31 @@ module JsonApiResource
       rescue JsonApiClient::Errors::ServerError=> e
         []
       end
+
+      private
+
+      QUERY_RESULT_METHOD_IDENTIFIER = "query_result_"
+
+      # When we return a collection, these extra attributes on top of the result array from JsonApiClient are present.
+      # When we find just one thing and return the first element like ActiveRecord would,
+      # we lose these things.  We want them, so we will assign them to this object.
+      def get_single_result(result_set)
+        single_result = result_set.first
+
+        single_result.methods.select{|method_name| is_query_result_setter_method(method_name)}.each do |setter_method_name|
+          attribute_part_only = setter_method_name.to_s.gsub(QUERY_RESULT_METHOD_IDENTIFIER, "").gsub("=", "")
+          if (result_set.methods.include?(attribute_part_only.to_sym))
+            single_result.send(setter_method_name, result_set.send(attribute_part_only))
+          end
+        end
+
+        return single_result
+      end
+
+      def is_query_result_setter_method(method_name)
+        method_name.to_s.start_with?(QUERY_RESULT_METHOD_IDENTIFIER) && method_name.to_s.end_with?("=")
+      end
+
     end
   end
 end

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -55,10 +55,12 @@ module JsonApiResource
         self.client.send(match[1], args.first)
       elsif self.client.respond_to?(method.to_sym)
         is_method = self.client.methods.include?(method.to_sym)
-        if (is_method ? self.client.method(method.to_sym).arity : 0) == 0
+        argument_count = (is_method ? self.client.method(method.to_sym).arity : 0)
+        argument_count = args.length if argument_count == -1
+        if (argument_count == 0) || args.blank?
           self.client.send(method)
         else
-          self.client.send(method, args.first)
+          self.client.send(method, *args.take(argument_count))
         end
       else
         super


### PR DESCRIPTION
Pass through query metadata from json_api_client even when we are returning just one result from a find
