### PR TITLE
adding propagation of the meta block into empty result sets

### DIFF
--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -43,7 +43,7 @@ module JsonApiResource
 
         query_methods_for(result).each do |setter|
           getter = setter.to_s.gsub("=", "")
-          puts getter, results.respond_to?(getter), results.methods.respond_to?(getter), results.inspect
+          
           if results.respond_to? getter
 
             results_meta = results.send getter
@@ -73,8 +73,6 @@ module JsonApiResource
         else
           error_response 500, { name: "ServerError", message: e.message }
         end
-
-        result
       end
 
 

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -10,12 +10,12 @@ module JsonApiResource
 
       def find(id)
         return nil unless id.present?
-        set = (self.client_klass.find(id)).map! do |result|
+        results = self.client_klass.find(id).map! do |result|
           self.new(:client => result)
         end
-        set.size == 1 ? get_single_result(set) : set
+        results.size == 1 ? single_result(results) : results
       rescue JsonApiClient::Errors::ServerError => e
-        []
+        error_result e
       end
 
       def create(attr = {})
@@ -29,38 +29,54 @@ module JsonApiResource
         (self.client_klass.where(opts).all).map! do |result|
           self.new(:client => result)
         end
-      rescue JsonApiClient::Errors::ServerError=> e
-        []
+      rescue JsonApiClient::Errors::ServerError => e
+        error_result e
       end
 
       private
 
-      QUERY_RESULT_METADATA_SETTERS = [:meta=, :linked_data=, :errors=]
-
       # When we return a collection, these extra attributes on top of the result array from JsonApiClient are present.
       # When we find just one thing and return the first element like ActiveRecord would,
       # we lose these things.  We want them, so we will assign them to this object.
-      def get_single_result(result_set)
-        single_result = result_set.first
+      def single_result(results)
+        result = results.first
 
-        query_methods(single_result).each do |setter|
+        query_methods_for(result).each do |setter|
           getter = setter.to_s.gsub("=", "")
-          if (result_set.methods.respond_to?(getter.to_sym))
-            single_result.send(setter, result_set.send(getter))
+          puts getter, results.respond_to?(getter), results.methods.respond_to?(getter), results.inspect
+          if results.respond_to? getter
+
+            results_meta = results.send getter
+            
+            result.send setter, results_meta
           end
         end
 
-        return single_result
+        return result
       end
 
-      def query_methods(single_obj)
-        methods = []
-        QUERY_RESULT_METADATA_SETTERS.each do |setter|
-          methods << setter if single_obj.respond_to?(setter)
+      def query_methods_for(result)
+        [:meta=, :linked_data=, :errors=].select do |setter|
+          result.respond_to?(setter)
         end
-        methods
       end
 
+      def error_result(e)
+        result = JsonApiClient::ResultSet.new
+        case e.class 
+   
+        when JsonApiClient::Errors::NotFound
+          result.meta = {status: 404, errors: "RecordNotFound"}
+   
+        when JsonApiClient::Errors::UnexpectedStatus
+          result.meta = {status: e.code, errors: "UnexpectedStatus"}
+        
+        else
+          result.meta = {status: 500, errors: "ServerError"}
+        end
+
+        result
+      end
     end
   end
 end

--- a/lib/json_api_resource/version.rb
+++ b/lib/json_api_resource/version.rb
@@ -1,3 +1,3 @@
 module JsonApiResource
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
minor code cleanup and propagating the meta block up to the resource when an error comes up through the client. 
