### PR TITLE
Fix errors for find

### DIFF
--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -45,6 +45,7 @@ module JsonApiResource
 
         result.meta = results.meta
 
+        # There will never be errors here but this provides a good default for forms
         result.errors = ActiveModel::Errors.new(result)
 
         result.linked_data = results.linked_data if results.respond_to? :linked_data

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -45,7 +45,7 @@ module JsonApiResource
 
         result.meta = results.meta
 
-        result.errors = ApiErrors(results.errors)
+        result.errors = ActiveModel::Errors.new(result)
 
         result.linked_data = results.linked_data if results.respond_to? :linked_data
 

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -45,9 +45,6 @@ module JsonApiResource
 
         result.meta = results.meta
 
-        # There will never be errors here but this provides a good default for forms
-        result.errors = ActiveModel::Errors.new(result)
-
         result.linked_data = results.linked_data if results.respond_to? :linked_data
 
         return result

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -38,6 +38,12 @@ module JsonApiResource
       end
     end
 
+    def update_attributes(attrs = {})
+      run_callbacks :update_attributes do
+        self.client.update_attributes(attrs)
+      end
+    end
+
     def attributes=(attr = {})
       client_params = attr.delete(:client)
       if attr.is_a? self.client_klass


### PR DESCRIPTION
When doing a find, there cannot be any errors.  We just need to default it to ActiveModel::Errors.
ApiErrors returns different things sometimes, and we cannot load some things using [] or {}, if it expected ActiveModel::Errors.
