### PR TITLE
Tests & interface changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem 'rake'
 
 group :test do
   gem 'simplecov'
+  gem 'minitest-stub_any_instance'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'rake'
+
+group :test do
+  gem 'simplecov'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     json_api_resource (0.4.5)
       activemodel
+      activesupport
       json_api_client (~> 0.5)
       json_api_client_mock (~> 0.2)
 
@@ -35,6 +36,7 @@ GEM
       mocha
     metaclass (0.0.4)
     minitest (5.8.4)
+    minitest-stub_any_instance (1.0.1)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multipart-post (2.0.0)
@@ -56,6 +58,7 @@ PLATFORMS
 
 DEPENDENCIES
   json_api_resource!
+  minitest-stub_any_instance
   rake
   simplecov
   webmock (> 0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,26 @@ PATH
   remote: .
   specs:
     json_api_resource (0.4.5)
+      activemodel
       json_api_client (~> 0.5)
       json_api_client_mock (~> 0.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activemodel (4.2.5.1)
+      activesupport (= 4.2.5.1)
+      builder (~> 3.1)
+    activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.2)
+    builder (3.2.2)
     crack (0.3.2)
+    docile (1.1.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     i18n (0.7.0)
@@ -28,11 +34,16 @@ GEM
       json_api_client (>= 0.3.4)
       mocha
     metaclass (0.0.4)
-    minitest (5.8.3)
+    minitest (5.8.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multipart-post (2.0.0)
     rake (0.9.4)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -46,7 +57,5 @@ PLATFORMS
 DEPENDENCIES
   json_api_resource!
   rake
+  simplecov
   webmock (> 0)
-
-BUNDLED WITH
-   1.10.6

--- a/json_api_resource.gemspec
+++ b/json_api_resource.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json_api_client", '~> 0.5'
   s.add_dependency "json_api_client_mock", '~> 0.2'
+  s.add_dependency "activemodel", '~> 0.2'
   
   s.add_development_dependency "webmock", '> 0'
   s.license = "MIT"

--- a/json_api_resource.gemspec
+++ b/json_api_resource.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.author = "Brandon Sislow"
   s.email = "brandon.silsow@gmail.com"
-  s.homepage = "http://gitlab.corp.avvo.com/api/api_resource"
+  s.homepage = "https://github.com/avvo/json_api_resource"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir.glob('test/*_test.rb')

--- a/json_api_resource.gemspec
+++ b/json_api_resource.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "json_api_client", '~> 0.5'
   s.add_dependency "json_api_client_mock", '~> 0.2'
-  s.add_dependency "activemodel", '~> 0.2'
+  s.add_dependency "activemodel"
   
   s.add_development_dependency "webmock", '> 0'
   s.license = "MIT"

--- a/json_api_resource.gemspec
+++ b/json_api_resource.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json_api_client", '~> 0.5'
   s.add_dependency "json_api_client_mock", '~> 0.2'
   s.add_dependency "activemodel"
+  s.add_dependency "activesupport"
   
   s.add_development_dependency "webmock", '> 0'
   s.license = "MIT"

--- a/lib/json_api_resource.rb
+++ b/lib/json_api_resource.rb
@@ -1,9 +1,11 @@
 require 'json_api_client'
 
 module JsonApiResource
-  autoload :Conversions,  'json_api_resource/conversions'
-  autoload :Queryable,    'json_api_resource/queryable'
-  autoload :Schemable,    'json_api_resource/schemable'
-  autoload :Resource,     'json_api_resource/resource'
-  autoload :Cacheable,    'json_api_resource/cacheable'
+  autoload :Cacheable,              'json_api_resource/cacheable'
+  autoload :Clientable,             'json_api_resource/clientable'
+  autoload :Conversions,            'json_api_resource/conversions'
+  autoload :JsonApiResourceError,   'json_api_resource/json_api_resource_error'
+  autoload :Queryable,              'json_api_resource/queryable'
+  autoload :Resource,               'json_api_resource/resource'
+  autoload :Schemable,              'json_api_resource/schemable'
 end

--- a/lib/json_api_resource.rb
+++ b/lib/json_api_resource.rb
@@ -1,3 +1,6 @@
+require 'active_model/model'
+require 'active_model/validations'
+require 'active_model/callback'
 require 'json_api_client'
 
 module JsonApiResource

--- a/lib/json_api_resource.rb
+++ b/lib/json_api_resource.rb
@@ -1,6 +1,3 @@
-require 'active_model/model'
-require 'active_model/validations'
-require 'active_model/callback'
 require 'json_api_client'
 
 module JsonApiResource

--- a/lib/json_api_resource/clientable.rb
+++ b/lib/json_api_resource/clientable.rb
@@ -1,0 +1,16 @@
+module JsonApiResource
+  module Clientable
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :client_class
+      self.client_class = nil
+
+      class << self
+        def wraps(client)
+          self.client_class = client
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/conversions.rb
+++ b/lib/json_api_resource/conversions.rb
@@ -6,6 +6,7 @@ module JsonApiResource
         when Hash then args.first
         when Array then { base: args }
         when String then { base: [args] }
+        when NilClass then { base: [[]]}
         else raise TypeError, "Cannot convert #{ args.inspect} to Error"
       end
     end

--- a/lib/json_api_resource/conversions.rb
+++ b/lib/json_api_resource/conversions.rb
@@ -47,7 +47,7 @@ module JsonApiResource
       case args.first
         when klass then args.first
         when Hash then klass.new(args.first)
-        when klass.client_klass then klass.new(args.first.attributes)
+        when klass.client_class then klass.new(args.first.attributes)
         when Array then args.first.map { |attr| ApiResource(klass, attr) }
         else raise TypeError, "Cannot convert #{ args.inspect} to #{klass}"
       end

--- a/lib/json_api_resource/conversions.rb
+++ b/lib/json_api_resource/conversions.rb
@@ -1,17 +1,5 @@
 module JsonApiResource
   module Conversions
-    def Address(*args)
-      case args.first
-        when Address then args.first
-        when Hash then Address.new(args.first)
-        when Address.client then Address.new(args.first.attributes)
-        when Array then args.first.map { |attr| Address(attr) }
-        when Integer then Address.new(* args)
-        when String then Address.new(* args.first.split(':'). map(&:to_i))
-        else raise TypeError, "Cannot convert #{ args.inspect} to Address"
-      end
-    end
-
     def ApiErrors(*args)
       case args.first
         when ActiveModel::Errors then args.first
@@ -55,19 +43,12 @@ module JsonApiResource
       end
     end
 
-    def Symbolize(*args)
-      case args.first
-        when String then args.first.underscore.parameterize('_').to_sym
-        else args.first
-      end
-    end
-
     def ApiResource(klass, *args)
       case args.first
         when klass then args.first
         when Hash then klass.new(args.first)
-        when klass.client then klass.new(args.first.attributes)
-        when Array then args.first.map { |attr| JsonApiResource(attr, klass) }
+        when klass.client_klass then klass.new(args.first.attributes)
+        when Array then args.first.map { |attr| ApiResource(klass, attr) }
         else raise TypeError, "Cannot convert #{ args.inspect} to #{klass}"
       end
     end

--- a/lib/json_api_resource/json_api_resource_error.rb
+++ b/lib/json_api_resource/json_api_resource_error.rb
@@ -1,0 +1,12 @@
+module JsonApiResource
+  class JsonApiResourceError < StandardError
+    def initialize(opts = {})
+      @klass    = opts.fetch :class, JsonApiResource::Resource
+      @message  = opts.fetch :message, ""
+    end
+
+    def message
+      "#{@klass}: #{@message}"
+    end
+  end
+end

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -14,7 +14,7 @@ module JsonApiResource
 
       def find(id)
         return nil unless id.present?
-        results = self.client_klass.find(id).map! do |result|
+        results = self.client_class.find(id).map! do |result|
           self.new(:client => result)
         end
         results.size == 1 ? single_result(results) : results
@@ -24,13 +24,13 @@ module JsonApiResource
 
       def create(attr = {})
         run_callbacks :create do
-          new(:client => self.client_klass.create(attr))
+          new(:client => self.client_class.create(attr))
         end
       end
 
       def where(opts = {})
         opts[:per_page] = opts.fetch(:per_page, self.per_page)
-        (self.client_klass.where(opts).all).map! do |result|
+        (self.client_class.where(opts).all).map! do |result|
           self.new(:client => result)
         end
       rescue JsonApiClient::Errors::ServerError => e

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -2,92 +2,80 @@ module JsonApiResource
   module Queryable
     extend ActiveSupport::Concern
 
-    attr_accessor :meta
-    attr_accessor :linked_data
-    attr_accessor :errors
+    included do
 
-    MAX_PAGES_FOR_ALL = 25
+      attr_accessor :meta
+      attr_accessor :linked_data
+      attr_accessor :errors
 
-    module ClassMethods
+      MAX_PAGES_FOR_ALL = 25
 
-      include JsonApiResource::Conversions
+      class << self
 
-      def find(id)
-        return nil unless id.present?
-        results = self.client_class.find(id).map! do |result|
-          self.new(:client => result)
+        include JsonApiResource::Conversions
+
+        def find(id)
+          return nil unless id.present?
+          results = self.client_class.find(id).map! do |result|
+            self.new(:client => result)
+          end
+          results.size == 1 ? single_result(results) : results
+        rescue JsonApiClient::Errors::ServerError => e
+          pretty_error e
         end
-        results.size == 1 ? single_result(results) : results
-      rescue JsonApiClient::Errors::ServerError => e
-        pretty_error e
-      end
 
-      def create(attr = {})
-        run_callbacks :create do
-          new(:client => self.client_class.create(attr))
+        def create(attr = {})
+          new(attr).save
+        rescue JsonApiClient::Errors::ServerError => e
+          pretty_error e
         end
-      end
 
-      def where(opts = {})
-        opts[:per_page] = opts.fetch(:per_page, self.per_page)
-        (self.client_class.where(opts).all).map! do |result|
-          self.new(:client => result)
+        def where(opts = {})
+          opts[:per_page] = opts.fetch(:per_page, self.per_page)
+          (self.client_class.where(opts).all).map! do |result|
+            self.new(:client => result)
+          end
+        rescue JsonApiClient::Errors::ServerError => e
+          pretty_error e
         end
-      rescue JsonApiClient::Errors::ServerError => e
-        pretty_error e
-      end
 
-      def all_without_pagination(opts = {})
-        page_total = 1
-        current_page = 1
-        all_results = []
-        until (current_page > page_total) || (current_page > MAX_PAGES_FOR_ALL)
-          page_of_results = where({:page => current_page}.merge(opts))
-          all_results << page_of_results
-          page_total = page_of_results.meta[:total_pages] || 1
-          current_page = current_page + 1
+        # When we return a collection, these extra attributes on top of the result array from JsonApiClient are present.
+        # When we find just one thing and return the first element like ActiveRecord would,
+        # we lose these things.  We want them, so we will assign them to this object.
+        def single_result(results)
+          result = results.first
+
+          result.meta = results.meta
+
+          result.linked_data = results.linked_data if results.respond_to? :linked_data
+
+          return result
         end
-        JsonApiClient::ResultSet.new(all_results.flatten.compact)
-      end
 
-      private
+        def pretty_error(e)
+          case e.class.to_s
 
-      # When we return a collection, these extra attributes on top of the result array from JsonApiClient are present.
-      # When we find just one thing and return the first element like ActiveRecord would,
-      # we lose these things.  We want them, so we will assign them to this object.
-      def single_result(results)
-        result = results.first
+          when 'JsonApiClient::Errors::NotFound'
+            error_response 404, { name: "RecordNotFound", message: e.message }
 
-        result.meta = results.meta
+          when 'JsonApiClient::Errors::UnexpectedStatus'
+            error_response e.code, { name: "UnexpectedStatus", message: e.message }
 
-        result.linked_data = results.linked_data if results.respond_to? :linked_data
-
-        return result
-      end
-
-      def pretty_error(e)
-        case e.class.to_s
-
-        when 'JsonApiClient::Errors::NotFound'
-          error_response 404, { name: "RecordNotFound", message: e.message }
-
-        when 'JsonApiClient::Errors::UnexpectedStatus'
-          error_response e.code, { name: "UnexpectedStatus", message: e.message }
-
-        else
-          error_response 500, { name: "ServerError", message: e.message }
+          else
+            error_response 500, { name: "ServerError", message: e.message }
+          end
         end
-      end
 
-      def error_response(status, error)
-        result = JsonApiClient::ResultSet.new
+        def error_response(status, error)
+          result = JsonApiClient::ResultSet.new
 
-        result.meta = {status: status}
+          result.meta = {status: status}
 
-        result.errors = ActiveModel::Errors.new(result)
-        result.errors.add(error[:name], Array(error[:message]).join(', '))
+          result.errors = ActiveModel::Errors.new(result)
+          result.errors.add(error[:name], Array(error[:message]).join(', '))
 
-        result
+          result
+        end
       end
     end
   end

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -25,9 +25,8 @@ module JsonApiResource
     attr_accessor :client, :cache_expires_in
     class_attribute :per_page
 
-    define_model_callbacks :save, :create, :update_attributes
+    define_model_callbacks :save, :update_attributes
 
-    around_create :catch_errors
     around_save   :catch_errors
     around_update_attributes :catch_errors
 

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -1,3 +1,12 @@
+require 'active_support'
+require 'active_support/concern'
+require 'active_support/core_ext/module'
+require 'active_support/core_ext/class/attribute'
+require 'active_model'
+require 'active_model/model'
+require 'active_model/validations'
+require 'active_model/callbacks'
+
 module JsonApiResource
   class Resource
     include ActiveModel::Model
@@ -17,6 +26,8 @@ module JsonApiResource
     around_create :catch_errors
     around_save   :catch_errors
     around_update_attributes :catch_errors
+
+    delegate :to_json, to: :attributes
 
     def initialize(opts={})
       self.client = self.client_klass.new(self.schema)

--- a/lib/json_api_resource/schemable.rb
+++ b/lib/json_api_resource/schemable.rb
@@ -9,10 +9,15 @@ module JsonApiResource
     end
 
     module ClassMethods
-      def property(opts = {})
-        opts.each do |attr_name,default|
-          self.schema[attr_name.to_sym] = default || nil
+      def properties(opts = {})
+        self.schema = schema.dup
+        opts.each_pair do |name, default|
+          property name, default
         end
+      end
+
+      def property(name, default = nil)
+        self.schema = schema.merge name.to_sym => default
       end
     end
 

--- a/lib/json_api_resource/schemable.rb
+++ b/lib/json_api_resource/schemable.rb
@@ -6,26 +6,19 @@ module JsonApiResource
     included do
       class_attribute :schema
       self.schema = {}
-    end
+      
+      class << self
+        def properties(opts = {})
+          self.schema = schema.dup
+          opts.each_pair do |name, default|
+            property name, default
+          end
+        end
 
-    module ClassMethods
-      def properties(opts = {})
-        self.schema = schema.dup
-        opts.each_pair do |name, default|
-          property name, default
+        def property(name, default = nil)
+          self.schema = schema.merge name.to_sym => default
         end
       end
-
-      def property(name, default = nil)
-        self.schema = schema.merge name.to_sym => default
-      end
     end
-
-    protected
-
-    def load_schema
-      self.client = self.client_klass.new(self.schema)
-    end
-
   end
 end

--- a/lib/json_api_resource/version.rb
+++ b/lib/json_api_resource/version.rb
@@ -1,3 +1,3 @@
 module JsonApiResource
-  VERSION = "0.4.5"
+  VERSION = "1.0.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,9 +13,14 @@ class UserClient < JsonApiClient::Resource
   self.site = "http://localhost:3000/api/1"
 end
 
+class AttributeClient < JsonApiClient::Resource
+  self.site = "http://localhost:3000/api/1"
+end
+
+# old model. Let's keep some backwards compat? maybe?
 class UserResource < JsonApiResource::Resource
   class << self
-    def client_klass
+    def client_class
       UserClient
     end
 
@@ -28,11 +33,7 @@ class UserResource < JsonApiResource::Resource
 end
 
 class PropUserResource < JsonApiResource::Resource
-  class << self
-    def client_klass
-      UserClient
-    end
-  end
+  wraps UserClient
 
   property :id, 0
   property :name, ""
@@ -40,11 +41,7 @@ class PropUserResource < JsonApiResource::Resource
 end
 
 class PropsUserResource < JsonApiResource::Resource
-  class << self
-    def client_klass
-      UserClient
-    end
-  end
+  wraps UserClient
 
   properties  id: 0,
               name: "",
@@ -52,11 +49,7 @@ class PropsUserResource < JsonApiResource::Resource
 end
 
 class PropPropsUserResource < JsonApiResource::Resource
-  class << self
-    def client_klass
-      UserClient
-    end
-  end
+  wraps UserClient
 
   properties  id: 0,
               name: ""

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,64 @@
 Bundler.require(:default, :test)
+
+require 'simplecov'
+SimpleCov.start
+
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'pp'
+require 'json_api_resource'
+require 'json_api_client'
 
-# test resources
-class User < JsonApiClient::Resource
+class UserClient < JsonApiClient::Resource
   self.site = "http://localhost:3000/api/1"
+end
+
+class UserResource < JsonApiResource::Resource
+  class << self
+    def client_klass
+      UserClient
+    end
+
+    def schema
+      { id: 0,
+        name: ""
+      }
+    end
+  end
+end
+
+class PropUserResource < JsonApiResource::Resource
+  class << self
+    def client_klass
+      UserClient
+    end
+  end
+
+  property :id, 0
+  property :name, ""
+  property :updated_at, nil
+end
+
+class PropsUserResource < JsonApiResource::Resource
+  class << self
+    def client_klass
+      UserClient
+    end
+  end
+
+  properties  id: 0,
+              name: "",
+              updated_at: nil
+end
+
+class PropPropsUserResource < JsonApiResource::Resource
+  class << self
+    def client_klass
+      UserClient
+    end
+  end
+
+  properties  id: 0,
+              name: ""
+  property :updated_at
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,11 +9,20 @@ require 'pp'
 require 'json_api_resource'
 require 'json_api_client'
 
-class UserClient < JsonApiClient::Resource
+class User < JsonApiClient::Resource
+  class_attribute :attribute_count
+  self.attribute_count = 0
+
   self.site = "http://localhost:3000/api/1"
+
+  def no_name
+    :no_name
+  end
+
+  collection_endpoint :search, request_method: :get
 end
 
-class AttributeClient < JsonApiClient::Resource
+class Attribute < JsonApiClient::Resource
   self.site = "http://localhost:3000/api/1"
 end
 
@@ -21,11 +30,11 @@ end
 class UserResource < JsonApiResource::Resource
   class << self
     def client_class
-      UserClient
+      User
     end
 
     def schema
-      { id: 0,
+      { id: nil,
         name: ""
       }
     end
@@ -33,25 +42,29 @@ class UserResource < JsonApiResource::Resource
 end
 
 class PropUserResource < JsonApiResource::Resource
-  wraps UserClient
+  wraps User
 
-  property :id, 0
+  property :id
   property :name, ""
   property :updated_at, nil
 end
 
 class PropsUserResource < JsonApiResource::Resource
-  wraps UserClient
+  wraps User
 
-  properties  id: 0,
+  properties  id: nil,
               name: "",
               updated_at: nil
 end
 
 class PropPropsUserResource < JsonApiResource::Resource
-  wraps UserClient
+  wraps User
 
-  properties  id: 0,
+  properties  id: nil,
               name: ""
   property :updated_at
+end
+
+def raise_client_error!
+  -> (*args){ raise JsonApiClient::Errors::ServerError.new("http://localhost:3000/api/1") }
 end

--- a/test/unit/authentication_test.rb
+++ b/test/unit/authentication_test.rb
@@ -1,5 +1,0 @@
-require 'test_helper'
-
-class AuthenticationTest < MiniTest::Unit::TestCase
-
-end

--- a/test/unit/cacheable_test.rb
+++ b/test/unit/cacheable_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class CacheableTest < MiniTest::Test
+
+  def setup
+    @resource = UserResource.new({id: 2, name: "Brandon Sislow"})
+  end
+
+  def test_can_generate_cache
+    refute_nil @resource.cache_key
+  end
+
+  def test_identical_objects_will_generate_the_same_key
+    new_key = UserResource.new({id: 2, name: "Brandon Sislow"}).cache_key
+    assert_equal new_key, @resource.cache_key
+  end
+
+  def test_different_objects_will_generate_different_keys
+    new_key = UserResource.new({id: 2, name: "not Brandon Sislow"}).cache_key
+    refute_equal new_key, @resource.cache_key
+  end
+
+end

--- a/test/unit/clinetable_test.rb
+++ b/test/unit/clinetable_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class ClientableTest < MiniTest::Test
+
+  def test_wraps_sets_client
+    assert_equal UserClient, UserResource.client_class
+  end
+
+  def test_wraps_overrides_previous_class
+    assert_equal UserClient, PropUserResource.client_class
+    PropUserResource.wraps AttributeClient
+    assert_equal AttributeClient, PropUserResource.client_class
+  end
+
+  def test_throws_if_no_client_present
+    assert_raises JsonApiResource::JsonApiResourceError do
+      JsonApiResource::Resource.new({})
+    end
+  end
+end

--- a/test/unit/clinetable_test.rb
+++ b/test/unit/clinetable_test.rb
@@ -3,13 +3,20 @@ require 'test_helper'
 class ClientableTest < MiniTest::Test
 
   def test_wraps_sets_client
-    assert_equal UserClient, UserResource.client_class
+    assert_equal User, UserResource.client_class
   end
 
   def test_wraps_overrides_previous_class
-    assert_equal UserClient, PropUserResource.client_class
-    PropUserResource.wraps AttributeClient
-    assert_equal AttributeClient, PropUserResource.client_class
+    assert_equal User, PropUserResource.client_class
+    PropUserResource.wraps Attribute
+    assert_equal Attribute, PropUserResource.client_class
+
+    # let's reset the client
+    UserResource.wraps User
+  end
+
+  def test_can_create_new
+
   end
 
   def test_throws_if_no_client_present

--- a/test/unit/conversions_test.rb
+++ b/test/unit/conversions_test.rb
@@ -27,7 +27,7 @@ class ConversionsTest < MiniTest::Test
 
   def test_api_errors_raises_on_garbage_input
     assert_raises TypeError do
-      ApiErrors(UserClient.new())
+      ApiErrors(User.new())
     end
   end
 
@@ -43,7 +43,7 @@ class ConversionsTest < MiniTest::Test
 
   def test_date_raises_on_garbage_input
     assert_raises TypeError do
-      Date(UserClient.new())
+      Date(User.new())
     end
   end
 
@@ -59,7 +59,7 @@ class ConversionsTest < MiniTest::Test
 
   def test_date_time_raises_on_garbage_input
     assert_raises TypeError do
-      DateTime(UserClient.new())
+      DateTime(User.new())
     end
   end
   
@@ -92,7 +92,7 @@ class ConversionsTest < MiniTest::Test
 
   def test_boolean_raises_on_garbage_input
     assert_raises TypeError do
-      Boolean(UserClient.new())
+      Boolean(User.new())
     end
   end
 
@@ -107,11 +107,11 @@ class ConversionsTest < MiniTest::Test
   end
 
   def test_api_resource_can_parse_client
-    assert_equal UserResource, ApiResource(UserResource, UserClient.new()).class
+    assert_equal UserResource, ApiResource(UserResource, User.new()).class
   end
 
   def test_api_resource_can_parse_array
-    assert_equal Array, ApiResource(UserResource, [{}, UserClient.new(), UserResource.new()]).class
+    assert_equal Array, ApiResource(UserResource, [{}, User.new(), UserResource.new()]).class
   end
 
   def test_api_resource_raises_on_garbage_input

--- a/test/unit/conversions_test.rb
+++ b/test/unit/conversions_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class Conversions_test < MiniTest::Test
+
+  def setup
+    @resource = User.new()
+  end
+
+
+  def test_something
+
+  end
+
+end

--- a/test/unit/conversions_test.rb
+++ b/test/unit/conversions_test.rb
@@ -1,14 +1,123 @@
 require 'test_helper'
 
-class Conversions_test < MiniTest::Test
+class ConversionsTest < MiniTest::Test
+  include JsonApiResource::Conversions
 
-  def setup
-    @resource = User.new()
+#------------- ApiErrors -------------
+
+  def test_api_errors_can_parse_api_errors
+    errors = ActiveModel::Errors.new({})
+    assert_equal ActiveModel::Errors, ApiErrors(errors).class
   end
 
+  def test_api_errors_can_parse_hash
+    errors  = { error: :bad }
+    assert_equal errors, ApiErrors(errors)
+  end
 
-  def test_something
+  def test_api_errors_can_parse_array
+    errors = [:good, :bad, :ugly]
+    assert_equal( { base: [errors] }, ApiErrors(errors) )
+  end
 
+  def test_api_errors_can_parse_string
+    errors = "Error. lol"
+    assert_equal( { base: [[errors]] }, ApiErrors(errors) )
+  end
+
+  def test_api_errors_raises_on_garbage_input
+    assert_raises TypeError do
+      ApiErrors(UserClient.new())
+    end
+  end
+
+#--------------- Date ----------------
+
+  def test_date_can_parse_string
+    assert_equal Date, Date("21-01-2015").class
+  end
+
+  def test_date_can_parse_date
+    assert_equal Date, Date(Date.new).class
+  end
+
+  def test_date_raises_on_garbage_input
+    assert_raises TypeError do
+      Date(UserClient.new())
+    end
+  end
+
+#------------- DateTime --------------
+
+  def test_date_time_can_parse_string
+    assert_equal DateTime, DateTime("21-01-2015").class
+  end
+
+  def test_date_time_can_parse_date
+    assert_equal DateTime, DateTime(DateTime.new).class
+  end
+
+  def test_date_time_raises_on_garbage_input
+    assert_raises TypeError do
+      DateTime(UserClient.new())
+    end
+  end
+  
+#-------------- Boolean --------------
+  
+  def test_boolean_can_parse_boolean
+    assert_equal true, Boolean(true)
+    assert_equal false, Boolean(false)
+  end
+
+  def test_boolean_can_parse_string
+    assert_equal true, Boolean("true")
+    assert_equal true, Boolean("1")
+
+    assert_equal false, Boolean("false")
+    assert_equal false, Boolean("0")
+  end
+
+  def test_boolean_can_parse_integer
+    assert_equal true, Boolean(15)
+
+    assert_equal false, Boolean(0)
+  end
+
+  def test_boolean_raises_on_garbage_string
+    assert_raises TypeError do
+      Boolean("LOL NOT TRUE")
+    end
+  end
+
+  def test_boolean_raises_on_garbage_input
+    assert_raises TypeError do
+      Boolean(UserClient.new())
+    end
+  end
+
+#------------ ApiResource ------------
+  
+  def test_api_resource_can_parse_reource
+    assert_equal UserResource, ApiResource(UserResource, UserResource.new()).class
+  end
+
+  def test_api_resource_can_parse_hash
+    assert_equal UserResource, ApiResource(UserResource, {}).class
+  end
+
+  def test_api_resource_can_parse_client
+    assert_equal UserResource, ApiResource(UserResource, UserClient.new()).class
+  end
+
+  def test_api_resource_can_parse_array
+    assert_equal Array, ApiResource(UserResource, [{}, UserClient.new(), UserResource.new()]).class
+  end
+
+  def test_api_resource_raises_on_garbage_input
+    assert_raises TypeError do
+      ApiResource(UserResource, "LOL NOT A RESOURCE")
+    end
   end
 
 end

--- a/test/unit/json_api_resource_error_test.rb
+++ b/test/unit/json_api_resource_error_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class JsonApiResourceErrorTest < MiniTest::Test
 
   def teardown
-    UserResource.wraps UserClient
+    UserResource.wraps User
   end
 
   def test_error_contains_message

--- a/test/unit/json_api_resource_error_test.rb
+++ b/test/unit/json_api_resource_error_test.rb
@@ -2,6 +2,9 @@ require 'test_helper'
 
 class JsonApiResourceErrorTest < MiniTest::Test
 
+  def teardown
+    UserResource.wraps UserClient
+  end
 
   def test_error_contains_message
     begin 

--- a/test/unit/json_api_resource_error_test.rb
+++ b/test/unit/json_api_resource_error_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class JsonApiResourceErrorTest < MiniTest::Test
+
+
+  def test_error_contains_message
+    begin 
+      UserResource.wraps nil
+      UserResource.new
+    rescue => e
+      assert_equal "UserResource: A resource must have a client class", e.message
+    end
+  end
+end

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
-class QueryableTest < MiniTest::Test
+class QuieriableTest < MiniTest::Test
 
   def setup
-    @resource = User.new()
+    @resource = UserResource.new({id: 1, name: "Brnadon Sislow"})
   end
 
 end

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -6,4 +6,31 @@ class QuieriableTest < MiniTest::Test
     @resource = UserResource.new({id: 1, name: "Brnadon Sislow"})
   end
 
+  def test_client_can_run_where
+    User.stub :where, JsonApiClient::Scope.new(id: 6) do
+      User.where.stub :all, JsonApiClient::ResultSet.new([User.new()]) do
+        result = UserResource.where id: 6
+        refute_empty result
+        assert_equal 1, result.count
+        assert_equal UserResource, result.first.class
+      end
+    end
+  end
+
+  def test_client_can_run_create
+    User.stub_any_instance :save, User.new() do
+      result = UserResource.create
+      refute_nil result
+      assert_equal UserResource, result.class
+    end
+  end
+
+  def test_client_can_run_find
+    User.stub :find, JsonApiClient::ResultSet.new([User.new()]) do
+      result = UserResource.find 6
+      refute_nil result
+      assert_equal UserResource, result.class
+    end
+  end
 end
+

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class QueryableTest < MiniTest::Test
+
+  def setup
+    @resource = User.new()
+  end
+
+end

--- a/test/unit/resource_test.rb
+++ b/test/unit/resource_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class ResourceTest < MiniTest::Test
+  def setup
+    @resource = UserResource.new
+  end
+
+  def test_new_resource_isnt_persisted
+    assert @resource.new_record?
+    refute @resource.persisted?
+  end
+
+  def test_resource_with_id_is_persisted
+    @resource.id = 1
+    assert @resource.persisted?
+    refute @resource.new_record?
+  end
+
+  def test_save_runs_callbacks
+    @resource.client.stub :save, User.new({}) do
+      assert_empty @resource.errors.messages
+      
+      @resource.client.stub :errors, {id: "something something"} do
+        @resource.save  
+        refute_empty @resource.errors.messages, "callbacks did not run. Should populate error array"
+        assert_equal( { id: [ "something something" ] }, @resource.errors.messages )
+      end
+    end
+  end
+
+  def test_update_attributes_runs_callbacks
+    @resource.client.stub :update_attributes, User.new({}) do
+      assert_empty @resource.errors.messages
+      
+      @resource.client.stub :errors, {id: "something something"} do
+        @resource.update_attributes id: -5
+        refute_empty @resource.errors.messages, "callbacks did not run. Should populate error array"
+        assert_equal( { id: [ "something something" ] }, @resource.errors.messages )
+      end
+    end
+  end
+
+  def test_method_missing_falls_through_to_client
+    assert_equal User.site, UserResource.site
+    assert_equal :no_name, @resource.no_name
+
+    User.stub :search, JsonApiClient::ResultSet.new([User.new()]) do
+      result = UserResource.search id: 6
+      refute_empty result
+      assert_equal 1, result.count
+      assert_equal UserResource, result.first.class
+    end
+
+    UserResource.attribute_count = 6
+
+    assert_equal UserResource.attribute_count, User.attribute_count
+  end
+
+  def test_respond_to_method_missing_falls_through_to_client
+    assert UserResource.respond_to? :site
+    assert UserResource.method :site
+    assert @resource.respond_to? :no_name
+    assert @resource.method :no_name
+  end
+
+  def test_client_errors_are_handled_on_save
+    @resource.client.stub :save, raise_client_error! do
+      response = @resource.save
+      assert_equal( { ServerError: ["Internal server error at: http://localhost:3000/api/1"] }, response.errors.messages )
+    end
+  end
+
+  def test_client_errors_are_handled_on_update
+    @resource.client.stub :update_attributes, raise_client_error! do
+      response = @resource.update_attributes id: -5
+      assert_equal( { ServerError: ["Internal server error at: http://localhost:3000/api/1"] }, response.errors.messages )
+    end
+  end
+
+   def test_client_errors_are_handled_method_missing
+     @resource.client.stub :no_name, raise_client_error! do
+      response = @resource.no_name
+      assert_equal( { ServerError: ["Internal server error at: http://localhost:3000/api/1"] }, response.errors.messages )
+    end
+
+    User.stub :attribute_count, raise_client_error! do
+      response = UserResource.attribute_count
+      assert_equal( { ServerError: ["Internal server error at: http://localhost:3000/api/1"] }, response.errors.messages )
+    end
+  end
+end

--- a/test/unit/schemable_test.rb
+++ b/test/unit/schemable_test.rb
@@ -3,18 +3,18 @@ require 'test_helper'
 class SchemableTest < MiniTest::Test
 
   def test_schemable_through_class_definition
-    assert_equal( { id: 0, name: "" }, UserResource.schema )
+    assert_equal( { id: nil, name: "" }, UserResource.schema )
   end
 
   def test_schemable_through_single_property
-    assert_equal( {id: 0, name: "", updated_at: nil}, PropUserResource.schema )
+    assert_equal( {id: nil, name: "", updated_at: nil}, PropUserResource.schema )
   end
 
   def test_schemable_though_properties_hash
-    assert_equal( {id: 0, name: "", updated_at: nil}, PropsUserResource.schema )
+    assert_equal( {id: nil, name: "", updated_at: nil}, PropsUserResource.schema )
   end
 
   def test_schemable_though_combination_of_properties
-    assert_equal( {id: 0, name: "", updated_at: nil}, PropPropsUserResource.schema )
+    assert_equal( {id: nil, name: "", updated_at: nil}, PropPropsUserResource.schema )
   end
 end

--- a/test/unit/schemable_test.rb
+++ b/test/unit/schemable_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SchemableTest < MiniTest::Test
+
+  def test_schemable_through_class_definition
+    assert_equal( { id: 0, name: "" }, UserResource.schema )
+  end
+
+  def test_schemable_through_single_property
+    assert_equal( {id: 0, name: "", updated_at: nil}, PropUserResource.schema )
+  end
+
+  def test_schemable_though_properties_hash
+    assert_equal( {id: 0, name: "", updated_at: nil}, PropsUserResource.schema )
+  end
+
+  def test_schemable_though_combination_of_properties
+    assert_equal( {id: 0, name: "", updated_at: nil}, PropPropsUserResource.schema )
+  end
+end


### PR DESCRIPTION
- Adding tests. Up to ~97% coverage. planning on going to 100% with a massive refactor. 
## BREAKING changes
- changing `property` to only take a single property and optional default
- removing `all_without_pagination`
- removing support for declaring the client class as 

``` ruby
class Resource < JsonApiResource::Resource
  def self.client_klass = Client
end
```
## Interface changes
- `properties` is the way to add many properties (as a hash)

``` ruby
  properties id: nil,
             name: ""
```
- `property` is the way to add a single property. `nil` is the default

``` ruby
  property :id
  property :name, ""
```
- `wraps` is the way to declare the `JsonApiClient` class the resource wraps

``` ruby
  wraps Client
```
