### PR TITLE
Fix the to_json infinite loop

### DIFF
--- a/lib/json_api_resource/cacheable.rb
+++ b/lib/json_api_resource/cacheable.rb
@@ -2,7 +2,7 @@ module JsonApiResource
   module Cacheable
     extend ActiveSupport::Concern
     def cache_key
-      @cache_key ||= Digest::SHA256.hexdigest(self.to_json)
+      @cache_key ||= Digest::SHA256.hexdigest(self.attributes.to_s)
     end
   end
 end


### PR DESCRIPTION
An instance variable can reference back to the same lawyer object with its own instance variable, and then we get a to_json infinite loop.  We can accomplish the same thing for our cache key another way.
