### PR TITLE
Associations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,3 @@ DEPENDENCIES
   rake
   simplecov
   webmock (> 0)
-
-BUNDLED WITH
-   1.11.2

--- a/lib/json_api_resource.rb
+++ b/lib/json_api_resource.rb
@@ -1,6 +1,8 @@
 require 'json_api_client'
 
 module JsonApiResource
+  autoload :Associatable,           'json_api_resource/associatable'
+  autoload :Associations,           'json_api_resource/associations'
   autoload :Cacheable,              'json_api_resource/cacheable'
   autoload :Clientable,             'json_api_resource/clientable'
   autoload :Connections,            'json_api_resource/connections'

--- a/lib/json_api_resource/associatable.rb
+++ b/lib/json_api_resource/associatable.rb
@@ -3,23 +3,51 @@ module JsonApiResource
     extend ActiveSupport::Concern
 
     included do
-      class << self
-        def belongs_to( name, opts = {} )
-          Associations::BelongsTo.create( self, name, opts )
-        end
 
-        def has_one( name, opts = {} )
-          Associations::HasOne.create( self, name, opts )
-        end
-
-        def has_many( name, opts = {} )
-          Associations::HasMany.create( self, name, opts )
-        end
-      end
+      class_attribute :associations
+      self.associations = {}
 
       attr_accessor :_cached_associations
 
-      # self._cached_associations = {}
+      class << self
+        def belongs_to( name, opts = {} )
+          process Associations::BelongsTo.new( self, name, opts )
+        end
+
+        def has_one( name, opts = {} )
+          process Associations::HasOne.new( self, name, opts )
+        end
+
+        def has_many( name, opts = {} )
+          process Associations::HasMany.new( self, name, opts )
+        end
+
+        private
+
+        def process(association)
+          add_association association
+          methodize association
+        end
+
+        def add_association(association)
+          self._associations = _associations.merge association.name => association
+        end
+
+        def methodize( association )
+          
+          method = lambda do 
+            unless _cached_associations.has_key? association.name
+              result = association.klass.send( association.action, association.key, opts )
+              result = association.process result
+              
+              _cached_associations[association.name] = result
+            end
+            _cached_associations[association.name]
+          end
+
+          associated_class.send :define_method, association, method
+        end
+      end
     end
   end
 end

--- a/lib/json_api_resource/associatable.rb
+++ b/lib/json_api_resource/associatable.rb
@@ -5,24 +5,15 @@ module JsonApiResource
     included do
       class << self
         def belongs_to( name, opts = {} )
-          association = Associations::BelongsTo.create( name, opts )
-          associate name, association
+          Associations::BelongsTo.create( self, name, opts )
         end
 
         def has_one( name, opts = {} )
-          association = Associations::HasOne.create( name, opts )
-          associate name, association
+          Associations::HasOne.create( self, name, opts )
         end
 
         def has_many( name, opts = {} )
-          association = Associations::HasMany.create( name, opts )
-          associate name, association
-        end
-
-        private
-
-        def associate( name, association )
-          define_method(name, association)
+          Associations::HasMany.create( self, name, opts )
         end
       end
 

--- a/lib/json_api_resource/associatable.rb
+++ b/lib/json_api_resource/associatable.rb
@@ -1,0 +1,35 @@
+module JsonApiResource
+  module Associatable
+    extend ActiveSupport::Concern
+
+    included do
+      class << self
+        def belongs_to( name, opts = {} )
+          association = Associations::BelongsTo.create( name, opts )
+          associate name, association
+        end
+
+        def has_one( name, opts = {} )
+          association = Associations::HasOne.create( name, opts )
+          associate name, association
+        end
+
+        def has_many( name, opts = {} )
+          association = Associations::HasMany.create( name, opts )
+          associate name, association
+        end
+
+        private
+
+        def associate( name, association )
+          define_method(name, association)
+        end
+      end
+
+      attr_accessor :_cached_associations
+
+      # self._cached_associations = {}
+    end
+  end
+end
+

--- a/lib/json_api_resource/associations.rb
+++ b/lib/json_api_resource/associations.rb
@@ -1,0 +1,8 @@
+module JsonApiResource
+  module Associations
+    autoload :Base,         'json_api_resource/associations/base.rb'
+    autoload :BelongsTo,    'json_api_resource/associations/belongs_to.rb'
+    autoload :HasOne,       'json_api_resource/associations/has_one.rb'
+    autoload :HasMany,      'json_api_resource/associations/has_many.rb'
+  end
+end

--- a/lib/json_api_resource/associations.rb
+++ b/lib/json_api_resource/associations.rb
@@ -4,5 +4,10 @@ module JsonApiResource
     autoload :BelongsTo,    'json_api_resource/associations/belongs_to.rb'
     autoload :HasOne,       'json_api_resource/associations/has_one.rb'
     autoload :HasMany,      'json_api_resource/associations/has_many.rb'
+
+
+    BELONGS_TO  = :belongs_to
+    HAS_ONE     = :has_one
+    HAS_MANY    = :has_many
   end
 end

--- a/lib/json_api_resource/associations.rb
+++ b/lib/json_api_resource/associations.rb
@@ -1,13 +1,17 @@
 module JsonApiResource
   module Associations
-    autoload :Base,         'json_api_resource/associations/base.rb'
-    autoload :BelongsTo,    'json_api_resource/associations/belongs_to.rb'
-    autoload :HasOne,       'json_api_resource/associations/has_one.rb'
-    autoload :HasMany,      'json_api_resource/associations/has_many.rb'
+    autoload :Base,               'json_api_resource/associations/base'
+    autoload :BelongsTo,          'json_api_resource/associations/belongs_to'
+    autoload :HasManyPrefetched,  'json_api_resource/associations/has_many_prefetched'
+    autoload :HasOne,             'json_api_resource/associations/has_one'
+    autoload :HasMany,            'json_api_resource/associations/has_many'
+    autoload :Preloader,          'json_api_resource/associations/preloader'
+    autoload :Preloaders,         'json_api_resource/associations/preloaders'
 
 
-    BELONGS_TO  = :belongs_to
-    HAS_ONE     = :has_one
-    HAS_MANY    = :has_many
+    BELONGS_TO          = :belongs_to
+    HAS_ONE             = :has_one
+    HAS_MANY            = :has_many
+    HAS_MANY_PREFETCHED = :has_many_prefetched
   end
 end

--- a/lib/json_api_resource/associations/base.rb
+++ b/lib/json_api_resource/associations/base.rb
@@ -1,45 +1,71 @@
 module JsonApiResource
   module Associations
     class Base
-      attr_accessor :name, :action, :key, :klass
+      attr_accessor :name, :action, :key, :opts
 
-      def initialize(associated_class, name, opts)
+      def initialize(associated_class, name, opts = {})
         self.name   = name.to_sym
-        self.action = opts.fetch :action, default_action
-        self.key    = opts.fetch :foreign_key do server_key(name, opts) end
-        self.klass  = opts.fetch :class  do derived_class( associated_class, name ) end
+        self.root   = associated_class
+        
+        self.action = opts.delete :action       do default_action end
+        self.key    = opts.delete :foreign_key  do server_key end
+        self.opts   = opts
+        validate_options
       end
 
+      def type
+        raise NotImplementedError
+      end
+
+      def query
+        raise NotImplementedError
+      end
+
+      # klass has to be lazy initted for circular dependencies
+      def klass
+        @klass ||= opts.delete :class do derived_class end
+      end
 
       def post_process( value )
         value
       end
 
-      def server_key( association, opts )
-        raise NotImplementedError
-      end
+      protected
 
-      def klass( associated_class, association, opts )
-        opts[:class] || derived_class( associated_class, association )
+      attr_accessor :root
+
+      def server_key
+        raise NotImplementedError
       end
       
-      def type
-        raise NotImplementedError
-      end
-
-      private
-
       def default_action
         raise NotImplementedError
       end
 
-      def derived_class( associated_class, association )
-        module_string = associated_class.to_s.split("::")[0 ... -1].join("::")
-        class_string  = association.to_s.singularize.camelize
+      def derived_class
+        module_string = root.to_s.split("::")[0 ... -1].join("::")
+        class_string  = name.to_s.singularize.camelize
         
         # we don't necessarily want to add :: to classes, in case they have a relative path or something
         class_string = [module_string, class_string].select{|s| s.present? }.join "::"
         class_string.constantize
+      end
+
+      RESERVED_KEYWORDS = [:attributes, :_associations, :_cached_associations, :schema, :client]
+
+      def validate_options
+        raise_unless action.present?, "Invalid action: #{root}.#{name}"
+        raise_unless    key.present?, "Invalid foreign_key for #{root}.#{name}"
+
+        raise_if RESERVED_KEYWORDS.include?(name), "'#{name}' is a reserved keyword for #{root}"
+      end
+
+      def raise_if condition, message
+        raise JsonApiResource::Errors::InvalidAssociation.new(class: root, message: message ) if condition
+      end
+
+      def raise_unless condition, message
+        raise_if !condition, message
       end
     end
   end

--- a/lib/json_api_resource/associations/base.rb
+++ b/lib/json_api_resource/associations/base.rb
@@ -1,0 +1,51 @@
+module JsonApiResource
+  module Associations
+    class Base
+      class << self
+        def create(association, opts)
+          assoc_class   = self.association_class( association, opts )
+          assoc_key     = self.association_key( association, opts )
+          assoc_builder = self
+
+          lambda do 
+            unless _cached_associations.has_key? association
+              puts assoc_class, assoc_builder.action, assoc_key, opts
+              result = assoc_class.send( assoc_builder.action, assoc_key, opts )
+              result = assoc_builder.post_process result
+              
+              _cached_associations[association] = result
+            end
+            _cached_associations[association]
+          end
+        end
+
+        def action
+          raise NotImplementedError
+        end
+
+        def post_process( value )
+          value
+        end
+
+        protected
+
+        def association_key( association, opts )
+          raise NotImplementedError
+        end
+
+        def association_class( association, opts )
+          opts[:class] || derived_class( association )
+        end
+
+        def derived_class( association )
+          module_string = to_s.split("::")[0 ... -1].join("::")
+          class_string  = association.to_s.singularize.camelize
+          
+          # we don't necessarily want to add :: to classes, in case they have a relative path or something
+          class_stirng = [module_string, class_string].select{|s| s.present? }.join "::"
+          class_string.constantize
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/base.rb
+++ b/lib/json_api_resource/associations/base.rb
@@ -2,22 +2,29 @@ module JsonApiResource
   module Associations
     class Base
       class << self
-        def create(association, opts)
+        def create(associated_class, association, opts)
           assoc_builder = self
 
-          lambda do 
+          assoc_class   = association_class( associated_class, association, opts )
+          assoc_key     = assoc_builder.association_key( association, opts )
+          assoc_action  = self.action
+          assoc_process = lambda {|value| post_process(value) }
+          
+          method = lambda do 
             unless _cached_associations.has_key? association
-              assoc_key   = assoc_builder.association_key( association, opts )
-              assoc_class = assoc_builder.association_class( association, opts, self.class )
 
-              result = assoc_class.send( assoc_builder.action, assoc_key, opts )
-              result = assoc_builder.post_process result
+              result = assoc_class.send( assoc_action, assoc_key, opts )
+              result = assoc_process result
               
               _cached_associations[association] = result
             end
             _cached_associations[association]
           end
+
+          associated_class.send :define_method, association, method
         end
+
+        protected
 
         def action
           raise NotImplementedError
@@ -31,16 +38,16 @@ module JsonApiResource
           raise NotImplementedError
         end
 
-        def association_class( association, opts, assocaited_class )
-          opts[:class] || derived_class( association, assocaited_class )
+        def association_class( associated_class, association, opts )
+          opts[:class] || derived_class( associated_class, association )
         end
 
-        def derived_class( association, assocaited_class )
-          module_string = assocaited_class.to_s.split("::")[0 ... -1].join("::")
+        def derived_class( associated_class, association )
+          module_string = associated_class.to_s.split("::")[0 ... -1].join("::")
           class_string  = association.to_s.singularize.camelize
           
           # we don't necessarily want to add :: to classes, in case they have a relative path or something
-          class_stirng = [module_string, class_string].select{|s| s.present? }.join "::"
+          class_string = [module_string, class_string].select{|s| s.present? }.join "::"
           class_string.constantize
         end
       end

--- a/lib/json_api_resource/associations/base.rb
+++ b/lib/json_api_resource/associations/base.rb
@@ -7,7 +7,7 @@ module JsonApiResource
       def initialize(associated_class, name, opts = {})
         self.name   = name.to_sym
         self.root   = associated_class
-        @opts       = opts.merge( ignore_pagination: true )
+        @opts       = opts.merge( skip_pagination: true )
         
         self.action = @opts.delete :action       do default_action end
         self.key    = @opts.delete :foreign_key  do server_key end

--- a/lib/json_api_resource/associations/base.rb
+++ b/lib/json_api_resource/associations/base.rb
@@ -1,55 +1,45 @@
 module JsonApiResource
   module Associations
     class Base
-      class << self
-        def create(associated_class, association, opts)
-          assoc_builder = self
+      attr_accessor :name, :action, :key, :klass
 
-          assoc_class   = association_class( associated_class, association, opts )
-          assoc_key     = assoc_builder.association_key( association, opts )
-          assoc_action  = self.action
-          assoc_process = lambda {|value| post_process(value) }
-          
-          method = lambda do 
-            unless _cached_associations.has_key? association
+      def initialize(associated_class, name, opts)
+        self.name   = name.to_sym
+        self.action = opts.fetch :action, default_action
+        self.key    = opts.fetch :foreign_key do server_key(name, opts) end
+        self.klass  = opts.fetch :class  do derived_class( associated_class, name ) end
+      end
 
-              result = assoc_class.send( assoc_action, assoc_key, opts )
-              result = assoc_process result
-              
-              _cached_associations[association] = result
-            end
-            _cached_associations[association]
-          end
 
-          associated_class.send :define_method, association, method
-        end
+      def post_process( value )
+        value
+      end
 
-        protected
+      def server_key( association, opts )
+        raise NotImplementedError
+      end
 
-        def action
-          raise NotImplementedError
-        end
+      def klass( associated_class, association, opts )
+        opts[:class] || derived_class( associated_class, association )
+      end
+      
+      def type
+        raise NotImplementedError
+      end
 
-        def post_process( value )
-          value
-        end
+      private
 
-        def association_key( association, opts )
-          raise NotImplementedError
-        end
+      def default_action
+        raise NotImplementedError
+      end
 
-        def association_class( associated_class, association, opts )
-          opts[:class] || derived_class( associated_class, association )
-        end
-
-        def derived_class( associated_class, association )
-          module_string = associated_class.to_s.split("::")[0 ... -1].join("::")
-          class_string  = association.to_s.singularize.camelize
-          
-          # we don't necessarily want to add :: to classes, in case they have a relative path or something
-          class_string = [module_string, class_string].select{|s| s.present? }.join "::"
-          class_string.constantize
-        end
+      def derived_class( associated_class, association )
+        module_string = associated_class.to_s.split("::")[0 ... -1].join("::")
+        class_string  = association.to_s.singularize.camelize
+        
+        # we don't necessarily want to add :: to classes, in case they have a relative path or something
+        class_string = [module_string, class_string].select{|s| s.present? }.join "::"
+        class_string.constantize
       end
     end
   end

--- a/lib/json_api_resource/associations/belongs_to.rb
+++ b/lib/json_api_resource/associations/belongs_to.rb
@@ -1,14 +1,16 @@
 module JsonApiResource
   module Associations
     class BelongsTo < Base
-      class << self
-        def action
-          :find
-        end
+      def action
+        :find
+      end
 
-        def association_key( association, opts )
-          "#{association}_id"
-        end
+      def server_key( association, opts )
+        "#{association}_id"
+      end
+
+      def type
+        JsonApiResource::Associations::BELONGS_TO
       end
     end
   end

--- a/lib/json_api_resource/associations/belongs_to.rb
+++ b/lib/json_api_resource/associations/belongs_to.rb
@@ -1,12 +1,16 @@
 module JsonApiResource
   module Associations
     class BelongsTo < Base
-      def action
+      def default_action
         :find
       end
 
-      def server_key( association, opts )
-        "#{association}_id"
+      def server_key
+        "#{name}_id"
+      end
+
+      def query(root_instance)
+        root_instance.id
       end
 
       def type

--- a/lib/json_api_resource/associations/belongs_to.rb
+++ b/lib/json_api_resource/associations/belongs_to.rb
@@ -9,8 +9,16 @@ module JsonApiResource
         "#{name}_id"
       end
 
-      def query(root_instance)
-        root_instance.id
+      def query( root_instance )
+        root_instance.send key
+      end
+
+      def callable?( root_instance )
+        root_instance.send(key).present?
+      end
+
+      def nil_default
+        nil
       end
 
       def type

--- a/lib/json_api_resource/associations/belongs_to.rb
+++ b/lib/json_api_resource/associations/belongs_to.rb
@@ -1,0 +1,15 @@
+module JsonApiResource
+  module Associations
+    class BelongsTo < Base
+      class << self
+        def action
+          :find
+        end
+
+        def association_key( association, opts )
+          "#{association}_id"
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/has_many.rb
+++ b/lib/json_api_resource/associations/has_many.rb
@@ -1,10 +1,6 @@
 module JsonApiResource
   module Associations
     class HasOne < Base
-      def post_process( value )
-        value.first
-      end
-
       def action
         :where
       end
@@ -14,7 +10,7 @@ module JsonApiResource
       end
 
       def type
-        JsonApiResource::Associations::HAS_ONE
+        JsonApiResource::Associations::HAS_MANY
       end
     end
   end

--- a/lib/json_api_resource/associations/has_many.rb
+++ b/lib/json_api_resource/associations/has_many.rb
@@ -1,12 +1,17 @@
 module JsonApiResource
   module Associations
-    class HasOne < Base
-      def action
+    class HasMany < Base
+      def default_action
         :where
       end
 
-      def association_key( association, opts )
-        raise "eff"
+      def server_key
+        class_name = root.to_s.demodulize.underscore
+        "#{class_name}_id"
+      end
+
+      def query(root_instance)
+        { key => root_instance.id }.merge(opts)
       end
 
       def type

--- a/lib/json_api_resource/associations/has_many.rb
+++ b/lib/json_api_resource/associations/has_many.rb
@@ -6,11 +6,15 @@ module JsonApiResource
       end
 
       def server_key
-        class_name = root.to_s.demodulize.underscore
+        class_name = self.root.to_s.demodulize.underscore
         "#{class_name}_id"
       end
 
-      def query(root_instance)
+      def callable?( root_instance )
+        true
+      end
+
+      def query( root_instance )
         { key => root_instance.id }.merge(opts)
       end
 

--- a/lib/json_api_resource/associations/has_many_prefetched.rb
+++ b/lib/json_api_resource/associations/has_many_prefetched.rb
@@ -1,0 +1,34 @@
+module JsonApiResource
+  module Associations
+    class HasManyPrefetched < Base
+      def default_action
+        :where
+      end
+
+      def server_key
+        opts[:prefetched_ids]
+      end
+
+      def query( root_instance )
+        { id: root_instance.send(key) }.merge(opts)
+      end
+
+      def callable?( root_instance )
+        root_instance.send(key).present?
+      end
+
+      def nil_default
+        []
+      end
+
+      def type
+        JsonApiResource::Associations::HAS_MANY_PREFETCHED
+      end
+
+      def validate_options
+        raise_unless key == server_key, "#{root}.#{name} cannot specify both prefetched_ids and a foreign key"
+        super
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/has_many_prefetched.rb
+++ b/lib/json_api_resource/associations/has_many_prefetched.rb
@@ -6,7 +6,7 @@ module JsonApiResource
       end
 
       def server_key
-        opts[:prefetched_ids]
+        @opts[:prefetched_ids]
       end
 
       def query( root_instance )

--- a/lib/json_api_resource/associations/has_one.rb
+++ b/lib/json_api_resource/associations/has_one.rb
@@ -2,15 +2,20 @@ module JsonApiResource
   module Associations
     class HasOne < Base
       def post_process( value )
-        value.first
+        Array(value).first
       end
 
-      def action
+      def default_action  
         :where
       end
 
-      def association_key( association, opts )
-        raise "eff"
+      def server_key
+        class_name = root.to_s.demodulize.underscore
+        "#{class_name}_id"
+      end
+
+      def query(root_instance)
+        { key => root_instance.id }.merge(opts)
       end
 
       def type

--- a/lib/json_api_resource/associations/has_one.rb
+++ b/lib/json_api_resource/associations/has_one.rb
@@ -1,0 +1,19 @@
+module JsonApiResource
+  module Associations
+    class HasOne < Base
+      class << self
+        def post_process( value )
+          value.first
+        end
+
+        def action
+          raise :find
+        end
+
+        def association_key( association, opts )
+          raise "eff"
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/has_one.rb
+++ b/lib/json_api_resource/associations/has_one.rb
@@ -10,12 +10,16 @@ module JsonApiResource
       end
 
       def server_key
-        class_name = root.to_s.demodulize.underscore
+        class_name = self.root.to_s.demodulize.underscore
         "#{class_name}_id"
       end
 
-      def query(root_instance)
+      def query( root_instance )
         { key => root_instance.id }.merge(opts)
+      end
+
+      def callable?( root_instance )
+        true
       end
 
       def type

--- a/lib/json_api_resource/associations/preloader.rb
+++ b/lib/json_api_resource/associations/preloader.rb
@@ -5,6 +5,7 @@ module JsonApiResource
 
       class << self
         def preload ( objects, preloads )
+          objects  = Array(objects)
           preloads = Array(preloads)
           
           preloads.each do |preload|
@@ -33,7 +34,6 @@ module JsonApiResource
         end
 
         def preloader_for( association )
-          puts association.inspect
           preloader_class = PREOLOADERS_FOR_ASSOCIATIONS[association.type]
           preloader_class.new association
         end

--- a/lib/json_api_resource/associations/preloader.rb
+++ b/lib/json_api_resource/associations/preloader.rb
@@ -1,0 +1,58 @@
+module JsonApiResource
+  module Associations
+    class Preloader
+      include JsonApiResource::Errors
+
+      class << self
+        def preload ( objects, preloads )
+          preloads = Array(preloads)
+          
+          preloads.each do |preload|
+
+            association = association_for objects, preload
+            
+            preloader   = preloader_for association
+
+            preloader.preload( objects )
+
+          end
+        end
+
+        private
+
+        def association_for( objects, preload )
+          # let's assert the objects are of a single class
+          verify_object_homogenity!(objects)
+
+          obj_class   = objects.first.class
+          association = obj_class._associations[preload]
+          
+          raise_if association.nil?, "'#{preload}' is not a valid association on #{obj_class}"
+
+          association
+        end
+
+        def preloader_for( association )
+          puts association.inspect
+          preloader_class = PREOLOADERS_FOR_ASSOCIATIONS[association.type]
+          preloader_class.new association
+        end
+
+        def verify_object_homogenity!( objects )
+          obj_class = objects.first.class
+          
+          objects.each do |obj|
+            raise_unless obj.is_a?(obj_class), "JsonApiResource::Associations::Preloader.preload called with a heterogenious array of objects."
+          end
+        end
+
+        PREOLOADERS_FOR_ASSOCIATIONS = {
+                                          JsonApiResource::Associations::BELONGS_TO          => JsonApiResource::Associations::Preloaders::BelongsToPreloader,
+                                          JsonApiResource::Associations::HAS_ONE             => JsonApiResource::Associations::Preloaders::HasOnePreloader,
+                                          JsonApiResource::Associations::HAS_MANY            => JsonApiResource::Associations::Preloaders::HasManyPreloader,
+                                          JsonApiResource::Associations::HAS_MANY_PREFETCHED => JsonApiResource::Associations::Preloaders::HasManyPrefetchedPreloader,
+                                        }
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders.rb
+++ b/lib/json_api_resource/associations/preloaders.rb
@@ -1,0 +1,12 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      autoload :Base,                         'json_api_resource/associations/preloaders/base'
+      autoload :BelongsToPreloader,           'json_api_resource/associations/preloaders/belongs_to_preloader'
+      autoload :Distributors,                 'json_api_resource/associations/preloaders/distributors'
+      autoload :HasManyPrefetchedPreloader,   'json_api_resource/associations/preloaders/has_many_prefetched_preloader'
+      autoload :HasManyPreloader,             'json_api_resource/associations/preloaders/has_many_preloader'
+      autoload :HasOnePreloader,              'json_api_resource/associations/preloaders/has_one_preloader'
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/base.rb
+++ b/lib/json_api_resource/associations/preloaders/base.rb
@@ -1,0 +1,38 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      class Base
+        include JsonApiResource::Errors
+
+        attr_accessor :association, :distributor
+        delegate :klass, :name, :action, :key, :opts, :post_process, to: :association
+
+        def initialize(association)
+          self.association = association
+          self.distributor = distributor_class.new association
+        end
+
+        def preload( objects )
+          query       = bulk_query( objects )
+          results     = klass.send action, query
+
+          distributor.distribute objects, results
+        end
+
+        private
+
+        def assign( objects, results )
+          raise NotImplementedError
+        end
+
+        def bulk_query( objects )
+          raise NotImplementedError
+        end
+
+        def distributor_class
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/belongs_to_preloader.rb
+++ b/lib/json_api_resource/associations/preloaders/belongs_to_preloader.rb
@@ -1,0 +1,17 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      class BelongsToPreloader < Base
+
+        def bulk_query( objects )
+          ids = objects.map{ |o| o.send(key) }.flatten.uniq
+          { id: ids }.merge(opts)
+        end
+
+        def distributor_class
+          JsonApiResource::Associations::Preloaders::Distributors::DistributorByTargetId
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/distributors.rb
+++ b/lib/json_api_resource/associations/preloaders/distributors.rb
@@ -1,0 +1,11 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      module Distributors
+        autoload :Base,                   'json_api_resource/associations/preloaders/distributors/base'
+        autoload :DistributorByObjectId,  'json_api_resource/associations/preloaders/distributors/distributor_by_object_id'
+        autoload :DistributorByTargetId,  'json_api_resource/associations/preloaders/distributors/distributor_by_target_id'
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/distributors/base.rb
+++ b/lib/json_api_resource/associations/preloaders/distributors/base.rb
@@ -1,0 +1,33 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      module Distributors
+        class Base
+          include JsonApiResource::Errors
+
+          attr_accessor :association
+          delegate :key, :post_process, :root, :name, to: :association
+
+          def initialize(association)
+            self.association = association
+          end
+
+          def distribute( targets, resutls )
+            validate_assignability!( resutls )
+            assign( targets, resutls )
+          end
+
+          private
+
+          def validate_assignability!( resutls )
+            raise NotImplementedError
+          end
+
+          def assign( targets, resutls )
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/distributors/distributor_by_object_id.rb
+++ b/lib/json_api_resource/associations/preloaders/distributors/distributor_by_object_id.rb
@@ -1,0 +1,28 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      module Distributors
+        class DistributorByObjectId < Base
+
+          def assign( targets, results )
+            targets.each do |target|
+                        
+              id = target.id
+              
+              result = results.select{ |r| r.send(key) == id }
+
+              target._cached_associations ||= {}
+              target._cached_associations[name] = post_process result
+            end
+          end
+
+          def validate_assignability!( results )
+            results.each do |obj|
+              raise_unless obj.respond_to?(key), "preloading #{root}.#{name} failed: results don't respond to '#{key}'"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/distributors/distributor_by_target_id.rb
+++ b/lib/json_api_resource/associations/preloaders/distributors/distributor_by_target_id.rb
@@ -1,0 +1,32 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      module Distributors
+        class DistributorByTargetId < Base
+
+          def assign( targets, results )
+            targets.each do |target|
+              
+              ids = Array(target.send(key))
+              
+              # this obejct doesn't have this association. skip
+              next unless ids.present?
+                
+              result = results.select{ |r| ids.include? r.id }
+
+              target._cached_associations ||= {}
+              target._cached_associations[name] = post_process result
+
+            end
+          end
+
+          def validate_assignability!( results )
+            results.each do |obj|
+              raise_unless obj.respond_to?(:id), "preloading #{root}.#{name} failed: results don't respond to 'id'"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/has_many_prefetched_preloader.rb
+++ b/lib/json_api_resource/associations/preloaders/has_many_prefetched_preloader.rb
@@ -1,0 +1,17 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      class HasManyPrefetchedPreloader < Base
+
+        def bulk_query( objects )
+          ids = objects.map{ |o| o.send(key) }.flatten.uniq
+          { id: ids }.merge(opts)
+        end
+
+        def distributor_class
+          JsonApiResource::Associations::Preloaders::Distributors::DistributorByTargetId
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/has_many_preloader.rb
+++ b/lib/json_api_resource/associations/preloaders/has_many_preloader.rb
@@ -1,0 +1,17 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      class HasManyPreloader < Base
+
+        def bulk_query( objects )
+          ids = objects.map(&:id)
+          { key => ids }.merge(opts)
+        end
+
+        def distributor_class
+          JsonApiResource::Associations::Preloaders::Distributors::DistributorByObjectId
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/associations/preloaders/has_one_preloader.rb
+++ b/lib/json_api_resource/associations/preloaders/has_one_preloader.rb
@@ -1,0 +1,17 @@
+module JsonApiResource
+  module Associations
+    module Preloaders
+      class HasOnePreloader < Base
+
+        def bulk_query( objects )
+          ids = objects.map(&:id)
+          { key => ids }.merge(opts)
+        end
+
+        def distributor_class
+          JsonApiResource::Associations::Preloaders::Distributors::DistributorByObjectId
+        end
+      end
+    end
+  end
+end

--- a/lib/json_api_resource/errors.rb
+++ b/lib/json_api_resource/errors.rb
@@ -1,5 +1,29 @@
 module JsonApiResource
   module Errors
+    extend ActiveSupport::Concern
+    included do
+
+      def raise_if( condition, message, error = JsonApiResource::Errors::InvalidAssociation )
+        self.class.raise_if condition, message, error
+      end
+
+      def raise_unless( condition, message, error = JsonApiResource::Errors::InvalidAssociation )
+        raise_if !condition, message, error
+      end
+
+
+      class << self
+
+        def raise_if( condition, message, error = JsonApiResource::Errors::InvalidAssociation )
+          raise error.new(class: self, message: message ) if condition
+        end
+
+        def raise_unless( condition, message, error = JsonApiResource::Errors::InvalidAssociation )
+          raise_if !condition, message, error
+        end
+      end
+    end
+
     class JsonApiResourceError < StandardError
       def initialize(opts = {})
         @klass    = opts.fetch :class, JsonApiResource::Resource

--- a/lib/json_api_resource/errors.rb
+++ b/lib/json_api_resource/errors.rb
@@ -13,5 +13,8 @@ module JsonApiResource
 
     class UnsuccessfulRequest < JsonApiResourceError
     end
+
+    class InvalidAssociation < JsonApiResourceError
+    end
   end
 end

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -13,7 +13,7 @@ module JsonApiResource
 
         MAX_PAGES_FOR_ALL = 25
 
-        def find(id)
+        def find(id, opts = {})
           return nil unless id.present?
 
           results = execute(:find, id: id)

--- a/lib/json_api_resource/queryable.rb
+++ b/lib/json_api_resource/queryable.rb
@@ -13,7 +13,7 @@ module JsonApiResource
 
         MAX_PAGES_FOR_ALL = 25
 
-        def find(id, opts = {})
+        def find(id)
           return nil unless id.present?
 
           results = execute(:find, id: id)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -37,7 +37,6 @@ module JsonApiResource
       self.attributes = opts
       self.errors = ActiveModel::Errors.new(self)
       self.populate_missing_fields
-      self._cached_associations = {}
     end
 
     def new_record?

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -24,6 +24,7 @@ module JsonApiResource
     include JsonApiResource::Conversions
     include JsonApiResource::Cacheable
     include JsonApiResource::ErrorHandleable
+    include JsonApiResource::Errors
     include JsonApiResource::Associatable
 
     attr_accessor :client, :cache_expires_in
@@ -32,7 +33,7 @@ module JsonApiResource
     delegate :to_json, to: :attributes
 
     def initialize(opts={})
-      raise( JsonApiResource::Errors::JsonApiResourceError, class: self.class, message: "A resource must have a client class" ) unless client_class.present?
+      raise_unless client_class.present?, "A resource must have a client class", JsonApiResource::Errors::JsonApiResourceError
 
       self.attributes = opts
       self.errors = ActiveModel::Errors.new(self)

--- a/lib/json_api_resource/resource.rb
+++ b/lib/json_api_resource/resource.rb
@@ -24,6 +24,7 @@ module JsonApiResource
     include JsonApiResource::Conversions
     include JsonApiResource::Cacheable
     include JsonApiResource::ErrorHandleable
+    include JsonApiResource::Associatable
 
     attr_accessor :client, :cache_expires_in
     class_attribute :per_page
@@ -36,6 +37,7 @@ module JsonApiResource
       self.attributes = opts
       self.errors = ActiveModel::Errors.new(self)
       self.populate_missing_fields
+      self._cached_associations = {}
     end
 
     def new_record?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,6 +58,62 @@ class PropPropsUserResource < JsonApiResource::Resource
   property :updated_at
 end
 
+
+module Account
+  module Client
+    class Base < JsonApiClient::Resource
+      self.site = "http://localhost:3000/api/1"
+    end
+
+    class User < Base
+      class_attribute :attribute_count
+      self.attribute_count = 0
+
+      def no_name
+        "no_name"
+      end
+
+      collection_endpoint :search, request_method: :get
+    end
+
+    class Attribute < Base
+    end
+
+    class PartnerUser < Base
+    end
+  end
+
+  module V1
+    class PartnerUser < JsonApiResource::Resource
+      wraps Account::Client::PartnerUser
+    end
+
+    class User < JsonApiResource::Resource
+      wraps Account::Client::User
+
+      properties  id: nil, 
+                  name: "",
+                  associated_website_user_id: nil,
+                  updated_at: nil
+
+      belongs_to :associated_website_user, class: Account::V1::PartnerUser
+    end
+
+    class Attribute < JsonApiResource::Resource
+      wraps Account::Client::Attribute
+
+      properties  id: nil,
+                  user_id: nil,
+                  name: "",
+                  value: "",
+                  updated_at: nil
+
+      belongs_to :user
+    end
+  end
+end
+
+
 def raise_client_error!
   -> (*args){ raise JsonApiClient::Errors::ServerError.new("http://localhost:3000/api/1") }
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,6 +81,15 @@ module Account
 
     class PartnerUser < Base
     end
+
+    class Image < Base
+    end
+
+    class Address < Base
+    end
+
+    class Friendship < Base
+    end
   end
 
   module V1
@@ -88,15 +97,16 @@ module Account
       wraps Account::Client::PartnerUser
     end
 
-    class User < JsonApiResource::Resource
-      wraps Account::Client::User
+    class Friendship < JsonApiResource::Resource
+      wraps Account::Client::Friendship
+    end
 
-      properties  id: nil, 
-                  name: "",
-                  associated_website_user_id: nil,
-                  updated_at: nil
+    class Image < JsonApiResource::Resource
+      wraps Account::Client::Image
+    end
 
-      belongs_to :associated_website_user, class: Account::V1::PartnerUser
+    class Address < JsonApiResource::Resource
+      wraps Account::Client::Address
     end
 
     class Attribute < JsonApiResource::Resource
@@ -109,6 +119,23 @@ module Account
                   updated_at: nil
 
       belongs_to :user
+    end
+
+    class User < JsonApiResource::Resource
+      wraps Account::Client::User
+
+      properties  id: nil, 
+                  name: "",
+                  associated_website_user_id: nil,
+                  updated_at: nil
+
+      belongs_to :associated_website_user, class: Account::V1::PartnerUser
+
+      has_one    :address
+      has_one    :profile_image, class: Account::V1::Image, type: :profile
+
+      has_many   :friendships
+      has_many   :attrs, class: Account::V1::Attribute
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,6 +90,12 @@ module Account
 
     class Friendship < Base
     end
+
+    class Permission < Base
+    end
+
+    class Thing < Base
+    end
   end
 
   module V1
@@ -107,6 +113,14 @@ module Account
 
     class Address < JsonApiResource::Resource
       wraps Account::Client::Address
+    end
+
+    class Permission < JsonApiResource::Resource
+      wraps Account::Client::Permission
+    end
+
+    class Thing < JsonApiResource::Resource
+      wraps Account::Client::Thing
     end
 
     class Attribute < JsonApiResource::Resource
@@ -127,15 +141,19 @@ module Account
       properties  id: nil, 
                   name: "",
                   associated_website_user_id: nil,
+                  permission_ids: [],
                   updated_at: nil
 
       belongs_to :associated_website_user, class: Account::V1::PartnerUser
 
       has_one    :address
       has_one    :profile_image, class: Account::V1::Image, type: :profile
+      has_one    :thing, foreign_key: :person_id
 
       has_many   :friendships
       has_many   :attrs, class: Account::V1::Attribute
+
+      has_many   :permissions, prefetched_ids: :permission_ids
     end
   end
 end

--- a/test/unit/associatable_test.rb
+++ b/test/unit/associatable_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class AssociatableTest < MiniTest::Test
+
+  def test_derived_class
+    assert_equal "Account::V1::User", Account::V1::Attribute.send( :derived_class, :user )
+    assert_equal "Account::V1::User", Account::V1::Attribute.send( :derived_class, "user" )
+    
+    assert_equal "UserResource", UserResource.send( :derived_class, :user_resource )
+    assert_equal "UserResource", UserResource.send( :derived_class, "user_resource" )
+  end
+
+  def test_belongs_to_creates_correct_method
+    assert Account::V1::Attribute.new.respond_to? :user
+  end
+
+  def test_belongs_to_works_with_impicit_class
+    Account::Client::User.stub :find, JsonApiClient::ResultSet.new([User.new(id: 2)]) do
+      attribute = Account::V1::Attribute.new({id: 1, user_id: 2})
+      result = attribute.user
+      refute_nil result
+      assert_equal Account::V1::User, result.class
+      assert_equal 2, result.id
+    end
+  end
+
+  def test_belongs_to_works_with_expicit_class
+    Account::Client::PartnerUser.stub :find, JsonApiClient::ResultSet.new([User.new(id: 2)]) do
+      user = Account::V1::User.new({id: 1, associated_website_user_id: 2})
+      result = user.associated_website_user
+      refute_nil result
+      assert_equal Account::V1::PartnerUser, result.class
+      assert_equal 2, result.id
+    end
+  end
+
+
+
+end

--- a/test/unit/associatable_test.rb
+++ b/test/unit/associatable_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class AssociatableTest < MiniTest::Test
 
   def test_derived_class
-    assert_equal "Account::V1::User", Account::V1::Attribute.send( :derived_class, :user )
-    assert_equal "Account::V1::User", Account::V1::Attribute.send( :derived_class, "user" )
+    assert_equal Account::V1::User, JsonApiResource::Associations::Base.send( :derived_class, Account::V1::Attribute, :user )
+    assert_equal Account::V1::User, JsonApiResource::Associations::Base.send( :derived_class, Account::V1::Attribute, "user" )
     
-    assert_equal "UserResource", UserResource.send( :derived_class, :user_resource )
-    assert_equal "UserResource", UserResource.send( :derived_class, "user_resource" )
+    assert_equal UserResource, JsonApiResource::Associations::Base.send( :derived_class, UserResource, :user_resource )
+    assert_equal UserResource, JsonApiResource::Associations::Base.send( :derived_class, UserResource, "user_resource" )
   end
 
   def test_belongs_to_creates_correct_method

--- a/test/unit/associatable_test.rb
+++ b/test/unit/associatable_test.rb
@@ -254,8 +254,8 @@ class AssociatableTest < MiniTest::Test
     perms_association = Account::V1::User._associations[:permissions]
     user              = Account::V1::User.new id: 5, permission_ids: [4]
 
-    assert_equal( { user_id: 5, ignore_pagination: true }, attrs_association.query(user) )
-    assert_equal( { id: [4], ignore_pagination: true }, perms_association.query(user) )
+    assert_equal( { user_id: 5, skip_pagination: true }, attrs_association.query(user) )
+    assert_equal( { id: [4], skip_pagination: true }, perms_association.query(user) )
   end
 end
 

--- a/test/unit/associatable_test.rb
+++ b/test/unit/associatable_test.rb
@@ -248,5 +248,14 @@ class AssociatableTest < MiniTest::Test
       JsonApiResource::Associations::Base.new( UserResource, :bla, class: UserResource, action: :where, foreign_key: :id ).default_nil
     end
   end
+
+  def test_non_query_opts_are_not_in_an_association_query
+    attrs_association = Account::V1::User._associations[:attrs]
+    perms_association = Account::V1::User._associations[:permissions]
+    user              = Account::V1::User.new id: 5, permission_ids: [4]
+
+    assert_equal( { user_id: 5, ignore_pagination: true }, attrs_association.query(user) )
+    assert_equal( { id: [4], ignore_pagination: true }, perms_association.query(user) )
+  end
 end
 

--- a/test/unit/associatable_test.rb
+++ b/test/unit/associatable_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class AssociatableTest < MiniTest::Test
 
   def test_derived_class
-    assert_equal Account::V1::User, JsonApiResource::Associations::Base.send( :derived_class, Account::V1::Attribute, :user )
-    assert_equal Account::V1::User, JsonApiResource::Associations::Base.send( :derived_class, Account::V1::Attribute, "user" )
+    assert_equal Account::V1::User, JsonApiResource::Associations::BelongsTo.new( Account::V1::Attribute, :user ).klass
+    assert_equal Account::V1::User, JsonApiResource::Associations::BelongsTo.new( Account::V1::Attribute, "user" ).klass
     
-    assert_equal UserResource, JsonApiResource::Associations::Base.send( :derived_class, UserResource, :user_resource )
-    assert_equal UserResource, JsonApiResource::Associations::Base.send( :derived_class, UserResource, "user_resource" )
+    assert_equal UserResource, JsonApiResource::Associations::BelongsTo.new( UserResource, :user_resource ).klass
+    assert_equal UserResource, JsonApiResource::Associations::BelongsTo.new( UserResource, "user_resource" ).klass
   end
 
   def test_belongs_to_creates_correct_method
@@ -34,6 +34,159 @@ class AssociatableTest < MiniTest::Test
     end
   end
 
+  def test_belongs_to_caches_result
+    attribute = Account::V1::Attribute.new({id: 1, user_id: 2})
+    Account::Client::User.stub :find, JsonApiClient::ResultSet.new([User.new(id: 2)]) do
+      result = attribute.user
+      refute_nil result
+      assert_equal Account::V1::User, result.class
+      assert_equal 2, result.id
+    end
+
+    assert attribute.user
+  end
+
+  def test_has_one_creates_correct_method
+    assert Account::V1::User.new.respond_to? :profile_image
+    assert Account::V1::User.new.respond_to? :address
+  end
+
+  def test_has_one_works_with_impicit_class
+    Account::Client::Address.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Address.where.stub :all, JsonApiClient::ResultSet.new([Account::Client::Address.new(id: 2, user_id: 6)]) do
+        user = Account::V1::User.new({id: 6})
+        result = user.address
+        refute_nil result
+        assert_equal Account::V1::Address, result.class
+        assert_equal 6, result.user_id
+      end
+    end
+  end
+
+  def test_has_one_works_with_expicit_class
+    Account::Client::Image.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Image.where.stub :all, JsonApiClient::ResultSet.new([Account::Client::Image.new(id: 2, user_id: 6)]) do
+      
+        user = Account::V1::User.new({id: 1, associated_website_user_id: 2})
+        result = user.profile_image
+        refute_nil result
+        assert_equal Account::V1::Image, result.class
+        assert_equal 2, result.id
+      end
+    end
+  end
+
+  def test_has_one_caches_result
+    user = Account::V1::User.new({id: 6})
+    Account::Client::Address.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Address.where.stub :all, JsonApiClient::ResultSet.new([Account::Client::Address.new(id: 2, user_id: 6)]) do
+        result = user.address
+        refute_nil result
+        assert_equal Account::V1::Address, result.class
+        assert_equal 6, result.user_id
+      end
+    end
+
+    assert user.address
+  end
+
+  def test_has_many_creates_correct_method
+    assert Account::V1::User.new.respond_to? :attrs
+    assert Account::V1::User.new.respond_to? :friendships
+  end
+
+  def test_has_many_works_with_impicit_class
+    Account::Client::Friendship.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Friendship.where.stub :all, JsonApiClient::ResultSet.new([ Account::Client::Friendship.new(id: 2, user_id: 6), 
+                                                                                  Account::Client::Friendship.new(id: 3, user_id: 6)]) do
+        user = Account::V1::User.new({id: 6})
+        result = user.friendships
+        refute_nil result
+        assert_equal JsonApiClient::ResultSet, result.class
+        assert_equal [Account::V1::Friendship, Account::V1::Friendship], result.map(&:class)
+        assert_equal [2, 3], result.map(&:id)
+      end
+    end
+  end
+
+  def test_has_many_works_with_expicit_class
+    Account::Client::Attribute.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Attribute.where.stub :all, JsonApiClient::ResultSet.new([ Account::Client::Attribute.new(id: 2, user_id: 6), 
+                                                                                 Account::Client::Attribute.new(id: 3, user_id: 6)]) do
+        user = Account::V1::User.new({id: 1, associated_website_user_id: 2})
+        result = user.attrs
+        refute_nil result
+        assert_equal JsonApiClient::ResultSet, result.class
+        assert_equal [Account::V1::Attribute, Account::V1::Attribute], result.map(&:class)
+        assert_equal [2, 3], result.map(&:id)
+      end
+    end
+  end
+
+  def test_has_many_caches_result
+    user = Account::V1::User.new({id: 6})
+    Account::Client::Attribute.stub :where, JsonApiClient::Scope.new(user_id: 6) do
+      Account::Client::Attribute.where.stub :all, JsonApiClient::ResultSet.new([ Account::Client::Attribute.new(id: 2, user_id: 6), 
+                                                                                 Account::Client::Attribute.new(id: 3, user_id: 6)]) do
+        user = Account::V1::User.new({id: 1, associated_website_user_id: 2})
+        result = user.attrs
+        refute_nil result
+        assert_equal JsonApiClient::ResultSet, result.class
+        assert_equal [Account::V1::Attribute, Account::V1::Attribute], result.map(&:class)
+        assert_equal [2, 3], result.map(&:id)
+      end
+    end
+
+    assert user.attrs
+  end
+
+  def test_associations_will_asplode_with_invalid_action
+    assert_raises JsonApiResource::Errors::InvalidAssociation do
+      UserResource.belongs_to :user_resource, action: nil
+    end
+  end
+
+  def test_associations_will_asplode_with_invalid_foreign_key
+    assert_raises JsonApiResource::Errors::InvalidAssociation do
+      UserResource.has_one :prop_user_resource, foreign_key: nil
+    end
+  end
+
+  def test_associations_will_asplode_with_reserved_keyword_as_assocaition_name
+    JsonApiResource::Associations::Base::RESERVED_KEYWORDS.each do |keyword|
+      assert_raises JsonApiResource::Errors::InvalidAssociation do
+        Account::V1::User.has_many keyword
+      end
+    end
+  end
+
+  def test_association_objects_have_correct_types
+    bt = JsonApiResource::Associations::BelongsTo.new(UserResource, :user_prop_resource)
+    ho = JsonApiResource::Associations::HasOne.new(UserResource, :user_prop_resource)
+    hm = JsonApiResource::Associations::HasMany.new(UserResource, :user_prop_resource)
+
+    assert_equal JsonApiResource::Associations::BELONGS_TO, bt.type
+    assert_equal JsonApiResource::Associations::HAS_ONE, ho.type
+    assert_equal JsonApiResource::Associations::HAS_MANY, hm.type
+  end
 
 
+
+  def test_base_association_raises
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Base.new UserResource, :bla, class: UserResource
+    end
+
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Base.new UserResource, :bla, class: UserResource, action: :where
+    end
+
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Base.new( UserResource, :bla, class: UserResource, action: :where, foreign_key: :id ).type
+    end
+
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Base.new( UserResource, :bla, class: UserResource, action: :where, foreign_key: :id ).query
+    end
+  end
 end

--- a/test/unit/association_preloader_distributor_test.rb
+++ b/test/unit/association_preloader_distributor_test.rb
@@ -1,0 +1,89 @@
+require 'test_helper'
+
+class AssociationPreloaderDistributorTest < MiniTest::Test
+
+  def setup
+    @users =  [ Account::V1::User.new( id: 1, permission_ids: [1, 2] ), 
+                Account::V1::User.new( id: 2, permission_ids: [3, 4] ),
+              ]
+
+    @attrs =  [ Account::V1::Attribute.new( id: 1, user_id: 1 ),
+                Account::V1::Attribute.new( id: 2, user_id: 1 ),
+                Account::V1::Attribute.new( id: 3, user_id: 2 ),
+                Account::V1::Attribute.new( id: 4, user_id: 1 ),
+              ]
+
+    @perms =  [ Account::V1::Permission.new( id: 1 ),
+                Account::V1::Permission.new( id: 2 ),
+                Account::V1::Permission.new( id: 3 ),
+                Account::V1::Permission.new( id: 4 ),
+              ]
+
+    @things = [ Account::V1::Thing.new( {} ),
+                Account::V1::Thing.new( {} ),
+                Account::V1::Thing.new( {} ),
+                Account::V1::Thing.new( {} ),
+              ]
+
+  end
+
+  def test_base_distributor_raises
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Preloaders::Distributors::Base.new( nil ).send :validate_assignability!, []
+    end
+
+    assert_raises NotImplementedError do
+      JsonApiResource::Associations::Preloaders::Distributors::Base.new( nil ).send :assign, [], []
+    end
+  end
+
+  def test_distributor_by_object_id_correctly_assigns_results_to_targets
+    association = JsonApiResource::Associations::HasMany.new( Account::V1::User, 
+                                                              :attrs, 
+                                                              class: Account::V1::Attribute )
+
+    distributor =  JsonApiResource::Associations::Preloaders::Distributors::DistributorByObjectId.new association
+
+    distributor.distribute @users, @attrs
+
+    assert_equal @attrs.select{|r| r.user_id == 1}, @users.first.attrs
+  end
+
+  def test_distributor_by_object_id_validates_assignability
+    association = JsonApiResource::Associations::HasMany.new( Account::V1::User, 
+                                                              :things )
+
+    distributor =  JsonApiResource::Associations::Preloaders::Distributors::DistributorByObjectId.new association
+
+    assert_raises JsonApiResource::Errors::InvalidAssociation do
+      distributor.validate_assignability! @things
+    end
+  end
+
+
+  def test_distributor_by_target_id_correctly_assigns_results_to_targets
+    association = JsonApiResource::Associations::HasManyPrefetched.new( Account::V1::User, 
+                                                              :permissions, 
+                                                              prefetched_ids: :permission_ids )
+
+    distributor =  JsonApiResource::Associations::Preloaders::Distributors::DistributorByTargetId.new association
+
+    distributor.distribute @users, @perms
+
+    assert_equal @perms[0..1], @users.first.permissions
+    assert_equal @perms[2..3], @users.last.permissions
+  end
+
+  def test_distributor_by_target_id_validates_assignability
+
+    association = JsonApiResource::Associations::HasManyPrefetched.new( Account::V1::User, 
+                                                              :permissions, 
+                                                              prefetched_ids: :permission_ids )
+
+    distributor =  JsonApiResource::Associations::Preloaders::Distributors::DistributorByTargetId.new association
+
+    assert_raises JsonApiResource::Errors::InvalidAssociation do
+      distributor.validate_assignability! @things
+    end
+  end
+end

--- a/test/unit/association_preloader_test.rb
+++ b/test/unit/association_preloader_test.rb
@@ -2,6 +2,18 @@ require 'test_helper'
 
 class AssociationPreloaderTest < MiniTest::Test
   
+  def setup
+    @users =  [ Account::V1::User.new( id: 1, permission_ids: [1, 2] ), 
+                Account::V1::User.new( id: 2, permission_ids: [3, 4] ),
+              ]
+
+    @attrs =  [ Account::Client::Attribute.new( id: 1, user_id: 1 ),
+                Account::Client::Attribute.new( id: 2, user_id: 1 ),
+                Account::Client::Attribute.new( id: 3, user_id: 2 ),
+                Account::Client::Attribute.new( id: 4, user_id: 1 ),
+              ]
+  end
+
   def test_belongs_to_bulk_query
     users = (1..10).map do |id|
       Account::V1::User.new({id: id, associated_website_user_id: id})
@@ -57,8 +69,6 @@ class AssociationPreloaderTest < MiniTest::Test
     assert_equal [2, 3], hmp.bulk_query(users)[:id]
   end
 
-
-
   def test_belongs_to_preloader_correctly_assigns_objects
     users = (1..4).map do |id|
       Account::V1::User.new({id: id, associated_website_user_id: id})
@@ -69,25 +79,52 @@ class AssociationPreloaderTest < MiniTest::Test
     bt = JsonApiResource::Associations::Preloaders::BelongsToPreloader.new(bt)
 
     assert_equal [1, 2, 3, 4], bt.bulk_query(users)[:id]
-
   end
 
-  def test_belongs_to_preloader_explodes_on_unassignable_results
+  def test_preload_validates_and_distributes_objects
+    association = JsonApiResource::Associations::HasMany.new( Account::V1::User, 
+                                                              :attrs, 
+                                                              class: Account::V1::Attribute )
 
+    preloader =  JsonApiResource::Associations::Preloaders::HasManyPreloader.new association
+
+    Account::Client::Attribute.stub :where, JsonApiClient::Scope.new({}) do
+      Account::Client::Attribute.where.stub :all, JsonApiClient::ResultSet.new(@attrs) do
+        preloader.preload @users
+      end
+    end
+    assert_equal @attrs.select{|r| r.user_id == 1}.map(&:id), @users.first.attrs.map(&:id)
   end
 
 
-  def test__preloader_correctly_assigns_objects
-
+  def test_preloader_base_raises
+    assert_raises NotImplementedError do
+      base = JsonApiResource::Associations::Preloaders::Base.new nil
+    end
   end
 
-  def test__preloader_explodes_on_unassignable_results
+  def test_preloader_correctly_identifies_associations
+    association = Account::V1::User._associations[:attrs]
+    assert_equal association, JsonApiResource::Associations::Preloader.send( :association_for, @users, :attrs )
 
+    association = Account::V1::User._associations[:permissions]
+    assert_equal association, JsonApiResource::Associations::Preloader.send( :association_for, @users, :permissions )
+  
+    association = Account::V1::User._associations[:associated_website_user]
+    assert_equal association, JsonApiResource::Associations::Preloader.send( :association_for, @users, :associated_website_user )
+  
+    association = Account::V1::User._associations[:address]
+    assert_equal association, JsonApiResource::Associations::Preloader.send( :association_for, @users, :address )
+  
   end
 
-
-  def test_preloader
-
+  def test_preloader_end_to_end
+    Account::Client::Attribute.stub :where, JsonApiClient::Scope.new({}) do
+      Account::Client::Attribute.where.stub :all, JsonApiClient::ResultSet.new(@attrs) do
+        JsonApiResource::Associations::Preloader.preload @users, :attrs
+      end
+    end
+    assert_equal @attrs.select{|r| r.user_id == 1}.map(&:id), @users.first.attrs.map(&:id)
   end
 
 end

--- a/test/unit/association_preloader_test.rb
+++ b/test/unit/association_preloader_test.rb
@@ -1,0 +1,93 @@
+require 'test_helper'
+
+class AssociationPreloaderTest < MiniTest::Test
+  
+  def test_belongs_to_bulk_query
+    users = (1..10).map do |id|
+      Account::V1::User.new({id: id, associated_website_user_id: id})
+    end
+
+    bt = Account::V1::User._associations[:associated_website_user]
+
+    bt = JsonApiResource::Associations::Preloaders::BelongsToPreloader.new(bt)
+
+    assert bt.bulk_query(users).keys.include? :id
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], bt.bulk_query(users)[:id]
+  end
+
+  def test_has_one_bulk_query
+    users = (1..10).map do |id|
+      Account::V1::User.new({id: id})
+    end
+
+    ho = Account::V1::User._associations[:address]
+    ho = JsonApiResource::Associations::Preloaders::HasOnePreloader.new(ho)
+
+    assert ho.bulk_query(users).keys.include? :user_id
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ho.bulk_query(users)[:user_id]
+
+    ho = Account::V1::User._associations[:thing]
+    ho = JsonApiResource::Associations::Preloaders::HasOnePreloader.new(ho)
+
+    assert ho.bulk_query(users).keys.include? :person_id
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], ho.bulk_query(users)[:person_id]
+  end
+
+  def test_has_many_bulk_query
+    users = (1..10).map do |id|
+      Account::V1::User.new({id: id})
+    end
+
+    hm = Account::V1::User._associations[:address]
+    hm = JsonApiResource::Associations::Preloaders::HasManyPreloader.new(hm)
+
+    assert hm.bulk_query(users).keys.include? :user_id
+    assert_equal [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], hm.bulk_query(users)[:user_id]
+  end
+
+  def test_has_many_prefetched_bulk_query
+    users = (1..10).map do |id|
+      Account::V1::User.new({id: id, permission_ids: [2, 3]})
+    end
+
+    hmp = Account::V1::User._associations[:permissions]
+    hmp = JsonApiResource::Associations::Preloaders::HasManyPrefetchedPreloader.new(hmp)
+
+    assert hmp.bulk_query(users).keys.include? :id
+    assert_equal [2, 3], hmp.bulk_query(users)[:id]
+  end
+
+
+
+  def test_belongs_to_preloader_correctly_assigns_objects
+    users = (1..4).map do |id|
+      Account::V1::User.new({id: id, associated_website_user_id: id})
+    end
+
+    bt = Account::V1::User._associations[:associated_website_user]
+
+    bt = JsonApiResource::Associations::Preloaders::BelongsToPreloader.new(bt)
+
+    assert_equal [1, 2, 3, 4], bt.bulk_query(users)[:id]
+
+  end
+
+  def test_belongs_to_preloader_explodes_on_unassignable_results
+
+  end
+
+
+  def test__preloader_correctly_assigns_objects
+
+  end
+
+  def test__preloader_explodes_on_unassignable_results
+
+  end
+
+
+  def test_preloader
+
+  end
+
+end

--- a/test/unit/queryable_test.rb
+++ b/test/unit/queryable_test.rb
@@ -50,7 +50,6 @@ class QueryableTest < MiniTest::Test
     User.stub :where, raise_client_error! do
       assert_raises JsonApiResource::Errors::UnsuccessfulRequest do
         response = PropUserResource.where id: -5
-        assert_equal 500, response.meta[:status]
       end
     end
   end

--- a/test/unit/server_connection_test.rb
+++ b/test/unit/server_connection_test.rb
@@ -15,7 +15,6 @@ class ServerConnectionTest < MiniTest::Test
     User.stub :where, raise_client_error! do
       assert_raises JsonApiResource::Errors::UnsuccessfulRequest do
         response = PropUserResource.where id: -5
-        assert_equal 500, response.meta[:status]
       end
 
       assert_equal [JsonApiResource::Connections::ServerConnection, JsonApiClient::Errors::ServerError], $error


### PR DESCRIPTION
adding an `ActiveRecord`-like interface for basic associations.

the general interface is

``` ruby
#{association} name, opts= {}
```

where the target class and foreign key is by default figured out from the `name`, but can be overriden
## assumptions
- the servers you're preloading from/associating have controller entities that respond to show(`find`) and index(`where`)
- **important**: the index(`where`) action has to support `skip_pagination`. Otherwise you may lose associations as they get capped by the per-page limit
## assocaitions
- `belongs_to` - your resource has the `#{object}_id` for the association.
  - calls `object_class.find`
- `has_one` - will call the server with `opts.merge "#{root_class}_id => root_object.id` and grab the first thing that comes back
  - calls `object_class.where`
- `has_many` - same as `has_one` but will give you the full array of objects
  - calls 'object_class.where`
### options
- `:foreign_key` - this is what the server will get as the key for `has_one` and `has_many`. `belongs_to` is weird and will send the key to the resource object. for example

``` ruby
class Admin < JsonApiResource::Resource
  wraps Service::Client::Admin

  property user_id
  # this one is a little weird
  belongs_to :person, foreign_key: :user_id, class: User
end
```
- `:action` - If you have a custom action you're using for lookup, you can override the default `where` and `find`. For example

``` ruby
class Service::Client::Superuser < Service::Client::Base
  # i don't know why you would have this, but whatever
  custom_endpoint :superuser_from_user_id, :on=> :collection, :request_method=> :get
end

class User
  wraps Service::Client::User
  has_one :superuser, action: :superuser_from_user_id
end
```

_NOTE: keep in mind, this will still make the call with the `opts.merge foreign_key => root_object.id` hash. If you want to override the query, you may want to consider 1: if the API is RESTful 2: rolling your own association._
- `:prefetched_ids` _(`has_many` only)_ -  in the case that the root object has a collection of ids that come preloaded in it

``` ruby
class User < JsonApiResource::Resource
  wraps Service::Client::User
  property address_ids, []

  has_many :addresses, prefetched_ids: :address_ids
end
```
### notes

`:through` is not supported, nor will it ever be, because of the hidden complexity and cost of n HTTP calls.
## Preloader

Sometimes you have many objects that you need to fetch associations for. It's expensive to have to iterate over them one by one and annoying to have to assign the results. Well, now there's a `Preloader` that can do all of that for you
### example

Let's say you have `user`s who have `address`es. 

``` ruby
class User < JsonApiResource::Resource
  wraps Service::Client::User

  # shiny new function yay
  has_many :addresses
end

class Address < JsonApiResource::Resource
  wraps Service::Client::Address
end
```

With the associations in place, you can now use them to preload all the addresses for your users in a single query.

``` ruby
@users = User.where id: [1, 2, 3, 4, 5]

# that's it. that's all you have to do.
JsonApiClient::Associations::Preloader.preload @users, :addresses

# all the users now have addresses assigned to them and will not hit the server again
puts @users.map &:addresses
```
### params

The `Preloader` takes 2 parameters
- the objects you want the associations to be tied to (`@users` in our example)
- the list of associations you want bulk fetched from the server as symbols. 
  - can be a single symbol, or a list
  - has to have a corresponding association on the objects, and the name has to match
### notes

This is a simple tool so don't expect too much magic. The Preloader will explode if
- the objects aren't the same class
- the results aren't the same class (although i don't know how that would be possible)
- the result set can't be matched to the objects
